### PR TITLE
Allow tasks to be run without defining workflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,11 @@ tonic-build = { version = "0.13.1", features = ["prost"] }
 anyhow = "1.0.99"
 dotenvy = "0.15.7"
 testcontainers = "0.25.0"
+
+[[example]]
+name = "simple"
+path = "examples/simple.rs"
+
+[[example]]
+name = "worker"
+path = "examples/worker.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ worker = []
 
 async-trait = "0.1.88"
 base64 = "0.22"
-derive_builder = "0.20.2"
 dyn-clone = "1.0.20"
 futures = "0.3.31"
 prost = "0.13"
@@ -35,6 +34,7 @@ tonic = { version = "0.13", features = [
     "tls-native-roots",
 ] }
 serde_repr = "^0.1"
+typed-builder = "0.21.2"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ worker = []
 
 async-trait = "0.1.88"
 base64 = "0.22"
+derive_builder = "0.20.2"
 dyn-clone = "1.0.20"
 futures = "0.3.31"
 prost = "0.13"
@@ -34,7 +35,6 @@ tonic = { version = "0.13", features = [
     "tls-native-roots",
 ] }
 serde_repr = "^0.1"
-typed-builder = "0.21.2"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,7 @@ path = "examples/simple.rs"
 [[example]]
 name = "worker"
 path = "examples/worker.rs"
+
+[[example]]
+name = "dag"
+path = "examples/dag.rs"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
          .max_runs(5)
          .build()
          .unwrap()
-         .add_workflow(workflow)
+         .add_task_or_workflow(workflow)
          .start()
          .await
          .unwrap();

--- a/examples/dag.rs
+++ b/examples/dag.rs
@@ -24,14 +24,17 @@ async fn main() {
     dotenvy::dotenv().ok();
     let hatchet = Hatchet::from_env().await.unwrap();
 
-    let first_task = hatchet.task(
-        "first_task",
-        async move |_input: EmptyModel, _ctx: Context| -> anyhow::Result<FirstTaskOutput> {
-            Ok(FirstTaskOutput {
-                output: "Hello World".to_string(),
-            })
-        },
-    );
+    let first_task = hatchet
+        .task(
+            "first_task",
+            async move |_input: EmptyModel, _ctx: Context| -> anyhow::Result<FirstTaskOutput> {
+                Ok(FirstTaskOutput {
+                    output: "Hello World".to_string(),
+                })
+            },
+        )
+        .build()
+        .unwrap();
 
     let second_task = hatchet
         .task(
@@ -44,12 +47,15 @@ async fn main() {
                 })
             },
         )
+        .build()
+        .unwrap()
         .add_parent(&first_task);
 
     let mut workflow = hatchet
         .workflow::<EmptyModel, WorkflowOutput>()
         .name(String::from("dag-workflow"))
         .build()
+        .unwrap()
         .add_task(first_task)
         .unwrap()
         .add_task(second_task)
@@ -64,6 +70,7 @@ async fn main() {
             .name(String::from("test-worker"))
             .max_runs(5)
             .build()
+            .unwrap()
             .add_task_or_workflow(workflow_clone)
             .start()
             .await

--- a/examples/dag.rs
+++ b/examples/dag.rs
@@ -1,0 +1,40 @@
+use anyhow;
+use hatchet_sdk::{Context, EmptyModel, Hatchet};
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+    let hatchet = Hatchet::from_env().await.unwrap();
+
+    let first_task = hatchet.task(
+        "first_task",
+        async move |_input: EmptyModel, _ctx: Context| -> anyhow::Result<serde_json::Value> {
+            Ok(serde_json::json!({"output": "Hello World"}))
+        },
+    );
+
+    let second_task = hatchet
+        .task(
+            "second_task",
+            async move |_input: EmptyModel, ctx: Context| -> anyhow::Result<serde_json::Value> {
+                let first_result = ctx.parent_output("first_task").await?;
+                println!(
+                    "First task said: {}",
+                    first_result.get("output").unwrap().to_string()
+                );
+                Ok(serde_json::json!({"final_result": "Completed"}))
+            },
+        )
+        .add_parent(&first_task);
+
+    let mut workflow = hatchet
+        .workflow::<EmptyModel, serde_json::Value>()
+        .name(String::from("dag-workflow"))
+        .build()
+        .add_task(first_task)
+        .unwrap()
+        .add_task(second_task)
+        .unwrap();
+
+    workflow.run_no_wait(EmptyModel, None).await.unwrap();
+}

--- a/examples/dag.rs
+++ b/examples/dag.rs
@@ -1,5 +1,5 @@
 use anyhow;
-use hatchet_sdk::{Context, EmptyModel, Hatchet};
+use hatchet_sdk::{Context, EmptyModel, Hatchet, Register, Runnable};
 use serde::{Deserialize, Serialize};
 
 #[tokio::main]
@@ -64,7 +64,7 @@ async fn main() {
             .name(String::from("test-worker"))
             .max_runs(5)
             .build()
-            .add_workflow(workflow_clone)
+            .add_task_or_workflow(workflow_clone)
             .start()
             .await
             .unwrap()

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -35,16 +35,15 @@ async fn main() {
     let task_clone = task.clone();
 
     let worker_handle = tokio::spawn(async move {
-        hatchet_clone
+        let mut worker = hatchet_clone
             .worker()
             .name(String::from("test-worker"))
             .max_runs(5)
             .build()
             .unwrap()
-            .add_task_or_workflow(task_clone)
-            .start()
-            .await
-            .unwrap()
+            .add_task_or_workflow(task_clone);
+
+        worker.start().await.unwrap()
     });
 
     // Wait for the worker to register the workflow with Hatchet

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,47 @@
+use anyhow;
+use hatchet_sdk::{Context, Hatchet};
+use serde::{Deserialize, Serialize};
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+    let hatchet = Hatchet::from_env().await.unwrap();
+
+    #[derive(Serialize, Deserialize)]
+    struct SimpleInput {
+        message: String,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct SimpleOutput {
+        message: String,
+    }
+
+    let task = hatchet.task(
+        "simple-task",
+        async move |input: SimpleInput, ctx: Context| -> anyhow::Result<SimpleOutput> {
+            ctx.log("Starting simple task").await?;
+            Ok(SimpleOutput {
+                message: input.message.to_lowercase(),
+            })
+        },
+    );
+
+    let mut workflow = hatchet
+        .workflow::<SimpleInput, SimpleOutput>()
+        .name(String::from("simple-workflow"))
+        .build()
+        .unwrap()
+        .add_task(task)
+        .unwrap();
+
+    workflow
+        .run_no_wait(
+            SimpleInput {
+                message: String::from("Hello, world!"),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -31,7 +31,6 @@ async fn main() {
         .workflow::<SimpleInput, SimpleOutput>()
         .name(String::from("simple-workflow"))
         .build()
-        .unwrap()
         .add_task(task)
         .unwrap();
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,4 @@
-use anyhow;
-use hatchet_sdk::{Context, Hatchet};
+use hatchet_sdk::{Context, Hatchet, Register, Runnable};
 use serde::{Deserialize, Serialize};
 
 #[tokio::main]
@@ -7,19 +6,21 @@ async fn main() {
     dotenvy::dotenv().ok();
     let hatchet = Hatchet::from_env().await.unwrap();
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Clone, Serialize, Deserialize)]
     struct SimpleInput {
         message: String,
     }
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Clone, Serialize, Deserialize)]
     struct SimpleOutput {
         message: String,
     }
 
-    let task = hatchet.task(
+    let mut task = hatchet.task(
         "simple-task",
-        async move |input: SimpleInput, ctx: Context| -> anyhow::Result<SimpleOutput> {
+        async move |input: SimpleInput,
+                    ctx: Context|
+                    -> Result<SimpleOutput, hatchet_sdk::HatchetError> {
             ctx.log("Starting simple task").await?;
             Ok(SimpleOutput {
                 message: input.message.to_lowercase(),
@@ -27,15 +28,26 @@ async fn main() {
         },
     );
 
-    let mut workflow = hatchet
-        .workflow::<SimpleInput, SimpleOutput>()
-        .name(String::from("simple-workflow"))
-        .build()
-        .add_task(task)
-        .unwrap();
+    let hatchet_clone = hatchet.clone();
+    let task_clone = task.clone();
 
-    workflow
-        .run_no_wait(
+    let worker_handle = tokio::spawn(async move {
+        hatchet_clone
+            .worker()
+            .name(String::from("test-worker"))
+            .max_runs(5)
+            .build()
+            .add_task_or_workflow(task_clone)
+            .start()
+            .await
+            .unwrap()
+    });
+
+    // Wait for the worker to register the workflow with Hatchet
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    let result = task
+        .run(
             SimpleInput {
                 message: String::from("Hello, world!"),
             },
@@ -43,4 +55,10 @@ async fn main() {
         )
         .await
         .unwrap();
+    println!(
+        "First task result: {}",
+        serde_json::to_string(&result).unwrap()
+    );
+
+    worker_handle.abort();
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,17 +16,20 @@ async fn main() {
         message: String,
     }
 
-    let mut task = hatchet.task(
-        "simple-task",
-        async move |input: SimpleInput,
-                    ctx: Context|
-                    -> Result<SimpleOutput, hatchet_sdk::HatchetError> {
-            ctx.log("Starting simple task").await?;
-            Ok(SimpleOutput {
-                message: input.message.to_lowercase(),
-            })
-        },
-    );
+    let mut task = hatchet
+        .task(
+            "simple-task",
+            async move |input: SimpleInput,
+                        ctx: Context|
+                        -> Result<SimpleOutput, hatchet_sdk::HatchetError> {
+                ctx.log("Starting simple task").await?;
+                Ok(SimpleOutput {
+                    message: input.message.to_lowercase(),
+                })
+            },
+        )
+        .build()
+        .unwrap();
 
     let hatchet_clone = hatchet.clone();
     let task_clone = task.clone();
@@ -37,6 +40,7 @@ async fn main() {
             .name(String::from("test-worker"))
             .max_runs(5)
             .build()
+            .unwrap()
             .add_task_or_workflow(task_clone)
             .start()
             .await

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -1,0 +1,48 @@
+use anyhow;
+use hatchet_sdk::{Context, Hatchet};
+use serde::{Deserialize, Serialize};
+
+#[tokio::main]
+async fn main() {
+    dotenvy::dotenv().ok();
+    let hatchet = Hatchet::from_env().await.unwrap();
+
+    #[derive(Serialize, Deserialize)]
+    struct SimpleInput {
+        message: String,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct SimpleOutput {
+        message: String,
+    }
+
+    let task = hatchet.task(
+        "simple-task",
+        async move |input: SimpleInput, ctx: Context| -> anyhow::Result<SimpleOutput> {
+            ctx.log("Starting simple task").await?;
+            Ok(SimpleOutput {
+                message: input.message.to_lowercase(),
+            })
+        },
+    );
+
+    let mut workflow = hatchet
+        .workflow::<SimpleInput, SimpleOutput>()
+        .name(String::from("simple-workflow"))
+        .build()
+        .unwrap()
+        .add_task(task)
+        .unwrap();
+
+    hatchet
+        .worker()
+        .name(String::from("simple-worker"))
+        .max_runs(5)
+        .build()
+        .unwrap()
+        .add_workflow(workflow)
+        .start()
+        .await
+        .unwrap();
+}

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -1,5 +1,5 @@
 use anyhow;
-use hatchet_sdk::{Context, Hatchet};
+use hatchet_sdk::{Context, Hatchet, Register};
 use serde::{Deserialize, Serialize};
 
 #[tokio::main]
@@ -39,7 +39,7 @@ async fn main() {
         .name(String::from("simple-worker"))
         .max_runs(5)
         .build()
-        .add_workflow(workflow)
+        .add_task_or_workflow(workflow)
         .start()
         .await
         .unwrap();

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -27,7 +27,7 @@ async fn main() {
         },
     );
 
-    let mut workflow = hatchet
+    let workflow = hatchet
         .workflow::<SimpleInput, SimpleOutput>()
         .name(String::from("simple-workflow"))
         .build()

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -17,20 +17,24 @@ async fn main() {
         message: String,
     }
 
-    let task = hatchet.task(
-        "simple-task",
-        async move |input: SimpleInput, ctx: Context| -> anyhow::Result<SimpleOutput> {
-            ctx.log("Starting simple task").await?;
-            Ok(SimpleOutput {
-                message: input.message.to_lowercase(),
-            })
-        },
-    );
+    let task = hatchet
+        .task(
+            "simple-task",
+            async move |input: SimpleInput, ctx: Context| -> anyhow::Result<SimpleOutput> {
+                ctx.log("Starting simple task").await?;
+                Ok(SimpleOutput {
+                    message: input.message.to_lowercase(),
+                })
+            },
+        )
+        .build()
+        .unwrap();
 
     let workflow = hatchet
         .workflow::<SimpleInput, SimpleOutput>()
         .name(String::from("simple-workflow"))
         .build()
+        .unwrap()
         .add_task(task)
         .unwrap();
 
@@ -39,6 +43,7 @@ async fn main() {
         .name(String::from("simple-worker"))
         .max_runs(5)
         .build()
+        .unwrap()
         .add_task_or_workflow(workflow)
         .start()
         .await

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -31,7 +31,6 @@ async fn main() {
         .workflow::<SimpleInput, SimpleOutput>()
         .name(String::from("simple-workflow"))
         .build()
-        .unwrap()
         .add_task(task)
         .unwrap();
 
@@ -40,7 +39,6 @@ async fn main() {
         .name(String::from("simple-worker"))
         .max_runs(5)
         .build()
-        .unwrap()
         .add_workflow(workflow)
         .start()
         .await

--- a/scripts/generate
+++ b/scripts/generate
@@ -21,6 +21,10 @@ find $tmp_dir -name "*.rs" -type f -exec sed -i '' 's/crate::/crate::clients::re
 # Due to possible bug, replace instances of <Object> with <serde_json::Value>
 find $tmp_dir -name "*.rs" -type f -exec sed -i '' 's/<Object>/<serde_json::Value>/g' {} +
 
+# Update event IDs to i64
+sed -i '' 's/pub id: i32/pub id: i64/g' "$tmp_dir/src/models/v1_task_event_list_200_response_rows_inner.rs"
+sed -i '' 's/pub fn new(id: i32/pub fn new(id: i64/g' "$tmp_dir/src/models/v1_task_event_list_200_response_rows_inner.rs"
+
 mv $tmp_dir/src/lib.rs $tmp_dir/src/mod.rs
 
 cp -r $tmp_dir/src/* src/clients/rest

--- a/src/clients/hatchet.rs
+++ b/src/clients/hatchet.rs
@@ -147,19 +147,21 @@ impl Hatchet {
     ///     let hatchet = Hatchet::from_env().await.unwrap();
     ///     let workflow = hatchet.workflow::<EmptyModel, EmptyModel>()
     ///         .name(String::from("my-workflow"))
-    ///         .build().unwrap()
+    ///         .build()
     ///         .add_task(hatchet.task("my-task", async move |input: EmptyModel, _ctx: Context| -> anyhow::Result<EmptyModel> {
     ///             Ok(EmptyModel)
     ///         }))
     ///         .unwrap();
     /// }
     /// ```
-    pub fn workflow<I, O>(&self) -> crate::workflow::WorkflowBuilder<I, O>
+    pub fn workflow<I, O>(
+        &self,
+    ) -> crate::workflow::WorkflowBuilder<I, O, ((), (Hatchet,), (), (), (), (), (), (), (), (), ())>
     where
         I: serde::Serialize + Send + Sync,
         O: serde::de::DeserializeOwned + Send + Sync,
     {
-        crate::workflow::WorkflowBuilder::<I, O>::default().client(self.clone())
+        crate::workflow::Workflow::<I, O>::builder().client(self.clone())
     }
 
     /// Create a new task.
@@ -193,10 +195,10 @@ impl Hatchet {
     /// #[tokio::main]
     /// async fn main() {
     ///     let hatchet = Hatchet::from_env().await.unwrap();
-    ///     let worker = hatchet.worker().name(String::from("my-worker")).build().unwrap();
+    ///     let worker = hatchet.worker().name(String::from("my-worker")).max_runs(5).build();
     /// }
     /// ```
-    pub fn worker(&self) -> crate::worker::worker::WorkerBuilder {
-        crate::worker::worker::WorkerBuilder::default().client(self.clone())
+    pub fn worker(&self) -> crate::worker::worker::WorkerBuilder<((), (), (Hatchet,), (), ())> {
+        crate::worker::worker::Worker::builder().client(self.clone())
     }
 }

--- a/src/clients/hatchet.rs
+++ b/src/clients/hatchet.rs
@@ -151,9 +151,10 @@ impl Hatchet {
     ///     let workflow = hatchet.workflow::<EmptyModel, EmptyModel>()
     ///         .name(String::from("my-workflow"))
     ///         .build()
+    ///         .unwrap()
     ///         .add_task(hatchet.task("my-task", async move |input: EmptyModel, _ctx: Context| -> anyhow::Result<EmptyModel> {
     ///             Ok(EmptyModel)
-    ///         }))
+    ///         }).build().unwrap())
     ///         .unwrap();
     /// }
     /// ```

--- a/src/clients/rest/models/v1_task_event_list_200_response_rows_inner.rs
+++ b/src/clients/rest/models/v1_task_event_list_200_response_rows_inner.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct V1TaskEventList200ResponseRowsInner {
     #[serde(rename = "id")]
-    pub id: i32,
+    pub id: i64,
     #[serde(rename = "taskId")]
     pub task_id: uuid::Uuid,
     #[serde(rename = "timestamp")]
@@ -40,7 +40,7 @@ pub struct V1TaskEventList200ResponseRowsInner {
 }
 
 impl V1TaskEventList200ResponseRowsInner {
-    pub fn new(id: i32, task_id: uuid::Uuid, timestamp: String, event_type: EventType, message: String) -> V1TaskEventList200ResponseRowsInner {
+    pub fn new(id: i64, task_id: uuid::Uuid, timestamp: String, event_type: EventType, message: String) -> V1TaskEventList200ResponseRowsInner {
         V1TaskEventList200ResponseRowsInner {
             id,
             task_id,

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,8 @@ impl HatchetConfig {
 
     fn decode_token(token_payload: &str) -> Result<serde_json::Value, HatchetError> {
         let payload_bytes = URL_SAFE_NO_PAD.decode(token_payload)?;
-        let payload_json: serde_json::Value = serde_json::from_slice(&payload_bytes)?;
+        let payload_json: serde_json::Value = serde_json::from_slice(&payload_bytes)
+            .map_err(|e| HatchetError::JsonDecodeError(e.to_string()))?;
         Ok(payload_json)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum HatchetError {
     #[error("Missing required environment variable \"{var}\".")]
     MissingEnvVar { var: String },
@@ -8,12 +8,12 @@ pub enum HatchetError {
     InvalidTokenFormat,
     #[error("Error decoding token: {0}.")]
     Base64DecodeError(#[from] base64::DecodeError),
-    #[error("Error decoding JSON.")]
-    JsonDecodeError(#[from] serde_json::Error),
+    #[error("Error decoding JSON: {0}")]
+    JsonDecodeError(String),
     #[error("Missing required field in JWT payload: {0}")]
     MissingTokenField(&'static str),
     #[error("Error sending API request: {0}")]
-    ApiRequestError(#[from] reqwest::Error),
+    ApiRequestError(String),
     #[error("Hatchet request failed:\nurl: {method} {url}\nstatus: {status}\ncontents: {body}")]
     HttpError {
         url: String,
@@ -22,11 +22,11 @@ pub enum HatchetError {
         body: String,
     },
     #[error("Error encoding JSON")]
-    JsonEncode(serde_json::Error),
-    #[error("Invalid authorization header in gRPC request")]
-    InvalidAuthHeader(#[from] tonic::metadata::errors::InvalidMetadataValue),
-    #[error("Unable to connect to gRPC server")]
-    GrpcConnect(#[from] tonic::transport::Error),
+    JsonEncode(String),
+    #[error("Invalid authorization header in gRPC request: {0}")]
+    InvalidAuthHeader(String),
+    #[error("Unable to connect to gRPC server: {0}")]
+    GrpcConnect(String),
     #[error("Error calling gRPC service: {0}")]
     GrpcCall(tonic::Status),
     #[error("Response missing output")]

--- a/src/features/runs.rs
+++ b/src/features/runs.rs
@@ -65,6 +65,8 @@ pub mod models {
         pub input: TaskInput,
         #[serde(rename = "taskExternalId")]
         pub task_external_id: String,
+        #[serde(rename = "actionId")]
+        pub action_id: Option<String>,
     }
 
     #[derive(Debug, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@
 //!     let mut workflow = hatchet.workflow::<SimpleInput, SimpleOutput>()
 //!         .name(String::from("simple-workflow"))
 //!         .build()
-//!         .unwrap()
 //!         .add_task(hatchet.task("simple-task", simple_task))
 //!         .unwrap();
 //!
@@ -51,7 +50,6 @@
 //!         .name(String::from("simple-worker"))
 //!         .max_runs(5)
 //!         .build()
-//!         .unwrap()
 //!         .add_workflow(workflow)
 //!         .start()
 //!         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! We recommend adding your Hatchet API token to a `.env` file and installing [dotenvy](https://crates.io/crates/dotenvy) to load it in your application.
 //!
 //! ```no_run
-//! use hatchet_sdk::{Context, Hatchet};
+//! use hatchet_sdk::{Context, Hatchet, Register, Runnable};
 //! use serde::{Deserialize, Serialize};
 //!
 //! // Define your input and output types
@@ -50,7 +50,7 @@
 //!         .name(String::from("simple-worker"))
 //!         .max_runs(5)
 //!         .build()
-//!         .add_workflow(workflow)
+//!         .add_task_or_workflow(workflow)
 //!         .start()
 //!         .await
 //!         .unwrap();
@@ -83,16 +83,17 @@ pub mod config;
 pub mod context;
 pub mod error;
 pub mod features;
-pub mod task;
+pub mod runnables;
 pub mod utils;
 pub mod worker;
-pub mod workflow;
 
 pub use clients::hatchet::Hatchet;
 pub use context::Context;
 pub use error::HatchetError;
-pub use task::Task;
+pub use runnables::Runnable;
+pub use runnables::Task;
+pub use runnables::TriggerWorkflowOptions;
+pub use runnables::Workflow;
 pub use utils::EmptyModel;
+pub use worker::Register;
 pub use worker::Worker;
-pub use workflow::TriggerWorkflowOptions;
-pub use workflow::Workflow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! We recommend adding your Hatchet API token to a `.env` file and installing [dotenvy](https://crates.io/crates/dotenvy) to load it in your application.
 //!
-//! ```no_run
+//! ```compile_fail
 //! use hatchet_sdk::{Context, Hatchet, Register, Runnable};
 //! use serde::{Deserialize, Serialize};
 //!

--- a/src/runnables/mod.rs
+++ b/src/runnables/mod.rs
@@ -2,6 +2,7 @@ mod runnable;
 mod task;
 mod workflow;
 
+pub(crate) use runnable::ExtractRunnableOutput;
 pub use runnable::Runnable;
 pub(crate) use task::ExecutableTask;
 pub use task::Task;

--- a/src/runnables/mod.rs
+++ b/src/runnables/mod.rs
@@ -1,0 +1,11 @@
+mod runnable;
+mod task;
+mod workflow;
+
+pub use runnable::Runnable;
+pub(crate) use task::ExecutableTask;
+pub use task::Task;
+pub(crate) use task::TaskError;
+pub use workflow::TriggerWorkflowOptions;
+pub use workflow::Workflow;
+pub use workflow::WorkflowBuilder;

--- a/src/runnables/mod.rs
+++ b/src/runnables/mod.rs
@@ -1,5 +1,5 @@
 mod runnable;
-mod task;
+pub mod task;
 mod workflow;
 
 pub(crate) use runnable::ExtractRunnableOutput;

--- a/src/runnables/runnable.rs
+++ b/src/runnables/runnable.rs
@@ -1,23 +1,56 @@
 use super::workflow::TriggerWorkflowOptions;
+use crate::Hatchet;
 use crate::error::HatchetError;
+use crate::features::runs::models::GetWorkflowRunResponse;
+use crate::features::runs::models::WorkflowStatus;
 use serde::Serialize;
+
 use serde::de::DeserializeOwned;
 
 #[async_trait::async_trait]
-pub trait Runnable<I, O>
+pub trait Runnable<I, O>: ExtractRunnableOutput<O> + Send + Sync + TriggerRunnable<I>
 where
-    I: Serialize + Send + Sync,
-    O: DeserializeOwned + Send + Sync,
+    I: Serialize + Send + Sync + DeserializeOwned + 'static,
+    O: DeserializeOwned + Send + Sync + 'static,
 {
+    async fn get_run(&self, run_id: &str) -> Result<GetWorkflowRunResponse, HatchetError>;
+
     async fn run(
         &mut self,
         input: I,
         options: Option<TriggerWorkflowOptions>,
-    ) -> Result<O, HatchetError>;
+    ) -> Result<O, HatchetError> {
+        let run_id = self.run_no_wait(input, options).await?;
+
+        // Wait 2 seconds for eventual consistency
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+        loop {
+            let workflow = self.get_run(&run_id).await?;
+            match workflow.run.status {
+                WorkflowStatus::Running => {}
+                WorkflowStatus::Completed => {
+                    return Ok(self.extract_output(workflow)?);
+                }
+                WorkflowStatus::Failed => {
+                    return Err(HatchetError::WorkflowFailed {
+                        error_message: workflow.run.error_message.clone(),
+                    });
+                }
+                _ => {}
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
 
     async fn run_no_wait(
         &mut self,
         input: I,
         options: Option<TriggerWorkflowOptions>,
     ) -> Result<String, HatchetError>;
+}
+
+pub(crate) trait ExtractRunnableOutput<O> {
+    fn extract_output(&self, runnable: GetWorkflowRunResponse) -> Result<O, HatchetError>;
 }

--- a/src/runnables/runnable.rs
+++ b/src/runnables/runnable.rs
@@ -1,5 +1,4 @@
 use super::workflow::TriggerWorkflowOptions;
-use crate::Hatchet;
 use crate::error::HatchetError;
 use crate::features::runs::models::GetWorkflowRunResponse;
 use crate::features::runs::models::WorkflowStatus;
@@ -8,7 +7,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 #[async_trait::async_trait]
-pub trait Runnable<I, O>: ExtractRunnableOutput<O> + Send + Sync + TriggerRunnable<I>
+pub trait Runnable<I, O>: ExtractRunnableOutput<O> + Send + Sync
 where
     I: Serialize + Send + Sync + DeserializeOwned + 'static,
     O: DeserializeOwned + Send + Sync + 'static,
@@ -51,6 +50,6 @@ where
     ) -> Result<String, HatchetError>;
 }
 
-pub(crate) trait ExtractRunnableOutput<O> {
+pub trait ExtractRunnableOutput<O> {
     fn extract_output(&self, runnable: GetWorkflowRunResponse) -> Result<O, HatchetError>;
 }

--- a/src/runnables/runnable.rs
+++ b/src/runnables/runnable.rs
@@ -1,0 +1,23 @@
+use super::workflow::TriggerWorkflowOptions;
+use crate::error::HatchetError;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+#[async_trait::async_trait]
+pub trait Runnable<I, O>
+where
+    I: Serialize + Send + Sync,
+    O: DeserializeOwned + Send + Sync,
+{
+    async fn run(
+        &mut self,
+        input: I,
+        options: Option<TriggerWorkflowOptions>,
+    ) -> Result<O, HatchetError>;
+
+    async fn run_no_wait(
+        &mut self,
+        input: I,
+        options: Option<TriggerWorkflowOptions>,
+    ) -> Result<String, HatchetError>;
+}

--- a/src/runnables/task.rs
+++ b/src/runnables/task.rs
@@ -77,26 +77,6 @@ where
     O: Serialize + Send + 'static,
     E: Into<Box<dyn std::error::Error + Send + Sync>> + Send + 'static,
 {
-    // pub fn new<F, Fut>(name: impl Into<String>, handler: F, client: Hatchet) -> Self
-    // where
-    //     F: FnOnce(I, Context) -> Fut + Send + Sync + Clone + 'static,
-    //     Fut: Future<Output = Result<O, E>> + Send + 'static,
-    // {
-    //     let name = name.into();
-    //     let handler = Arc::new(move |input: I, ctx: Context| {
-    //         let handler_clone = handler.clone();
-    //         Box::pin(handler_clone(input, ctx))
-    //             as Pin<Box<dyn Future<Output = Result<O, E>> + Send>>
-    //     });
-
-    //     Self {
-    //         client,
-    //         name,
-    //         handler,
-    //         parents: vec![],
-    //     }
-    // }
-
     pub fn add_parent<J, P, F>(mut self, parent: &Task<J, P, F>) -> Self {
         self.parents.push(parent.name.clone());
         self

--- a/src/runnables/task.rs
+++ b/src/runnables/task.rs
@@ -1,5 +1,11 @@
+use crate::Hatchet;
 use crate::clients::grpc::v1::workflows::CreateTaskOpts;
 use crate::context::Context;
+use crate::error::HatchetError;
+use crate::features::runs::models::GetWorkflowRunResponse;
+use crate::features::runs::models::WorkflowStatus;
+use crate::runnables::TriggerWorkflowOptions;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::pin::Pin;
@@ -41,7 +47,9 @@ pub trait ExecutableTask: Send + Sync + dyn_clone::DynClone {
 
 dyn_clone::clone_trait_object!(ExecutableTask);
 
+#[derive(Clone)]
 pub struct Task<I, O, E> {
+    client: Hatchet,
     pub(crate) name: String,
     handler:
         Arc<dyn Fn(I, Context) -> Pin<Box<dyn Future<Output = Result<O, E>> + Send>> + Send + Sync>,
@@ -50,11 +58,11 @@ pub struct Task<I, O, E> {
 
 impl<I, O, E> Task<I, O, E>
 where
-    I: for<'de> Deserialize<'de> + Send + 'static,
+    I: Serialize + for<'de> Deserialize<'de> + Send + 'static,
     O: Serialize + Send + 'static,
     E: Into<Box<dyn std::error::Error + Send + Sync>> + Send + 'static,
 {
-    pub fn new<F, Fut>(name: impl Into<String>, handler: F) -> Self
+    pub fn new<F, Fut>(name: impl Into<String>, handler: F, client: Hatchet) -> Self
     where
         F: FnOnce(I, Context) -> Fut + Send + Sync + Clone + 'static,
         Fut: Future<Output = Result<O, E>> + Send + 'static,
@@ -67,6 +75,7 @@ where
         });
 
         Self {
+            client,
             name,
             handler,
             parents: vec![],
@@ -117,6 +126,94 @@ where
             concurrency: vec![],
             conditions: None,
             schedule_timeout: None,
+        }
+    }
+
+    async fn trigger(
+        &mut self,
+        input: I,
+        options: TriggerWorkflowOptions,
+    ) -> Result<String, HatchetError> {
+        let input_json =
+            serde_json::to_value(&input).map_err(|e| HatchetError::JsonEncode(e.to_string()))?;
+        let response = self
+            .client
+            .workflow_client
+            .trigger_workflow(
+                crate::clients::grpc::v0::workflows::TriggerWorkflowRequest {
+                    name: self.name.clone(),
+                    input: input_json.to_string(),
+                    parent_id: None,
+                    parent_step_run_id: None,
+                    child_index: None,
+                    child_key: None,
+                    additional_metadata: options.additional_metadata.map(|v| v.to_string()),
+                    desired_worker_id: None,
+                    priority: None,
+                },
+            )
+            .await?;
+
+        Ok(response.workflow_run_id)
+    }
+
+    async fn get_run(&self, run_id: &str) -> Result<GetWorkflowRunResponse, HatchetError> {
+        self.client.workflow_rest_client.get(&run_id).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<I, O, E> super::Runnable<I, O> for Task<I, O, E>
+where
+    I: Serialize + DeserializeOwned + Send + Sync + 'static,
+    O: Serialize + DeserializeOwned + Send + Sync + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    async fn run_no_wait(
+        &mut self,
+        input: I,
+        options: Option<TriggerWorkflowOptions>,
+    ) -> Result<String, HatchetError> {
+        Ok(self.trigger(input, options.unwrap_or_default()).await?)
+    }
+
+    async fn run(
+        &mut self,
+        input: I,
+        options: Option<TriggerWorkflowOptions>,
+    ) -> Result<O, HatchetError> {
+        let run_id = self.run_no_wait(input, options).await?;
+
+        // Wait 2 seconds for eventual consistency
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+        loop {
+            let workflow = self.get_run(&run_id).await?;
+            match workflow.run.status {
+                WorkflowStatus::Running => {}
+                WorkflowStatus::Completed => {
+                    let task_output = workflow
+                        .tasks
+                        .iter()
+                        .find(|task| {
+                            task.action_id == Some(format!("{}:{}", &self.name, &self.name))
+                        })
+                        .and_then(|task| task.output.clone())
+                        .ok_or_else(|| HatchetError::MissingOutput)?;
+
+                    let output: O = serde_json::from_value(task_output)
+                        .map_err(|e| HatchetError::JsonDecodeError(e.to_string()))?;
+                    return Ok(output);
+                }
+                WorkflowStatus::Failed => {
+                    return Err(HatchetError::WorkflowFailed {
+                        error_message: workflow.run.error_message.clone(),
+                    });
+                }
+                _ => {}
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 }

--- a/src/runnables/task.rs
+++ b/src/runnables/task.rs
@@ -1,5 +1,5 @@
 use crate::Hatchet;
-use crate::clients::grpc::v1::workflows::CreateTaskOpts;
+use crate::clients::grpc::v1::workflows::{CreateTaskOpts, CreateWorkflowVersionRequest};
 use crate::context::Context;
 use crate::error::HatchetError;
 use crate::features::runs::models::GetWorkflowRunResponse;
@@ -111,7 +111,7 @@ where
         })
     }
 
-    pub(crate) fn to_proto(&self, workflow_name: &str) -> CreateTaskOpts {
+    fn to_task_proto(&self, workflow_name: &str) -> CreateTaskOpts {
         CreateTaskOpts {
             readable_id: self.name.clone(),
             action: format!("{workflow_name}:{}", &self.name),
@@ -126,6 +126,25 @@ where
             concurrency: vec![],
             conditions: None,
             schedule_timeout: None,
+        }
+    }
+
+    pub(crate) fn to_standalone_workflow_proto(&self) -> CreateWorkflowVersionRequest {
+        let task_proto = self.to_task_proto(&self.name);
+        CreateWorkflowVersionRequest {
+            name: self.name.clone(),
+            description: String::from(""),
+            version: String::from(""),
+            event_triggers: vec![],
+            cron_triggers: vec![],
+            tasks: vec![task_proto],
+            concurrency: None,
+            cron_input: None,
+            on_failure_task: None,
+            sticky: None,
+            default_priority: None,
+            concurrency_arr: vec![],
+            default_filters: vec![],
         }
     }
 

--- a/src/runnables/task.rs
+++ b/src/runnables/task.rs
@@ -111,7 +111,7 @@ where
         })
     }
 
-    fn to_task_proto(&self, workflow_name: &str) -> CreateTaskOpts {
+    pub(crate) fn to_task_proto(&self, workflow_name: &str) -> CreateTaskOpts {
         CreateTaskOpts {
             readable_id: self.name.clone(),
             action: format!("{workflow_name}:{}", &self.name),

--- a/src/runnables/workflow.rs
+++ b/src/runnables/workflow.rs
@@ -8,7 +8,6 @@ use crate::clients::grpc::v1::workflows::{
 use crate::clients::hatchet::Hatchet;
 use crate::error::HatchetError;
 use crate::features::runs::models::GetWorkflowRunResponse;
-use crate::features::runs::models::WorkflowStatus;
 use crate::runnables::task::{ExecutableTask, Task};
 use typed_builder::TypedBuilder;
 
@@ -113,10 +112,6 @@ where
             .await?;
 
         Ok(response.workflow_run_id)
-    }
-
-    async fn get_run(&self, run_id: &str) -> Result<GetWorkflowRunResponse, HatchetError> {
-        self.client.workflow_rest_client.get(&run_id).await
     }
 
     fn safely_get_action_name(&self, action_id: &str) -> Option<String> {

--- a/src/runnables/workflow.rs
+++ b/src/runnables/workflow.rs
@@ -9,9 +9,10 @@ use crate::clients::hatchet::Hatchet;
 use crate::error::HatchetError;
 use crate::features::runs::models::GetWorkflowRunResponse;
 use crate::runnables::task::{ExecutableTask, Task};
-use typed_builder::TypedBuilder;
+use derive_builder::Builder;
 
-#[derive(Clone, TypedBuilder)]
+#[derive(Clone, Builder)]
+#[builder(pattern = "owned")]
 pub struct Workflow<I, O> {
     pub(crate) name: String,
     client: Hatchet,

--- a/src/runnables/workflow.rs
+++ b/src/runnables/workflow.rs
@@ -57,7 +57,7 @@ where
             });
         }
 
-        self.tasks.push(task.to_proto(&self.name));
+        self.tasks.push(task.to_task_proto(&self.name));
         self.executable_tasks.push(task.into_executable());
         Ok(self)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,11 @@ pub(crate) fn add_grpc_auth_header<T>(
     request: &mut Request<T>,
     token: &str,
 ) -> Result<(), HatchetError> {
-    let token_header: MetadataValue<_> = format!("Bearer {}", token).parse()?;
+    let token_header: MetadataValue<_> = format!("Bearer {}", token).parse().map_err(
+        |e: tonic::metadata::errors::InvalidMetadataValue| {
+            HatchetError::InvalidAuthHeader(e.to_string())
+        },
+    )?;
     request.metadata_mut().insert("authorization", token_header);
     Ok(())
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod action_listener;
 pub(crate) mod task_dispatcher;
 pub mod worker;
 
+pub use worker::Register;
 pub use worker::Worker;
 pub use worker::WorkerBuilder;

--- a/src/worker/task_dispatcher.rs
+++ b/src/worker/task_dispatcher.rs
@@ -102,7 +102,7 @@ impl TaskDispatcher {
                         }
                     };
 
-                    let event_type = if result.unwrap().is_ok() { 2 } else { 3 };
+                    let event_type = if result.is_ok() { 2 } else { 3 };
 
                     let event = dispatcher::StepActionEvent {
                         worker_id: worker_id.to_string(),

--- a/src/worker/task_dispatcher.rs
+++ b/src/worker/task_dispatcher.rs
@@ -10,7 +10,7 @@ use crate::clients::grpc::v0::dispatcher;
 use crate::clients::hatchet::Hatchet;
 use crate::context::Context;
 use crate::error::HatchetError;
-use crate::task::ExecutableTask;
+use crate::runnables::ExecutableTask;
 use crate::utils::{EXECUTION_CONTEXT, ExecutionContext};
 
 #[derive(Clone)]
@@ -81,15 +81,15 @@ impl TaskDispatcher {
                         .expect("missing `input` field");
 
                     let result: Result<
-                        Result<serde_json::Value, crate::task::TaskError>,
+                        Result<serde_json::Value, crate::runnables::TaskError>,
                         Box<dyn std::any::Any + Send>,
                     > = AssertUnwindSafe(task.execute(input_value, context))
                         .catch_unwind()
                         .await;
 
                     let event_payload = match &result {
-                        Ok(Ok(output)) => output.to_string(),
-                        Ok(Err(e)) => e.to_string(),
+                        Ok(Ok(output)) => (2, output.to_string()),
+                        Ok(Err(e)) => (3, e.to_string()),
                         Err(panic_payload) => {
                             let panic_msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
                                 s.to_string()
@@ -98,11 +98,9 @@ impl TaskDispatcher {
                             } else {
                                 String::from("Unknown panic")
                             };
-                            format!("Task panicked: {panic_msg}")
+                            (3, format!("Task panicked: {panic_msg}"))
                         }
                     };
-
-                    let event_type = if result.is_ok() { 2 } else { 3 };
 
                     let event = dispatcher::StepActionEvent {
                         worker_id: worker_id.to_string(),
@@ -112,8 +110,8 @@ impl TaskDispatcher {
                         step_run_id: message.step_run_id.clone(),
                         action_id: message.action_id.clone(),
                         event_timestamp: Some(crate::utils::proto_timestamp_now()?),
-                        event_type,
-                        event_payload,
+                        event_type: event_payload.0,
+                        event_payload: event_payload.1,
                         retry_count: None,
                         should_not_retry: None,
                     };

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -183,8 +183,8 @@ impl Worker {
 
 impl<I, O> Register<Workflow<I, O>, I, O> for Worker
 where
-    I: Serialize + Send + Sync,
-    O: DeserializeOwned + Send + Sync,
+    I: Serialize + Send + Sync + 'static,
+    O: DeserializeOwned + Send + Sync + 'static,
 {
     fn add_task_or_workflow(mut self, workflow: Workflow<I, O>) -> Self {
         self.workflows.push(workflow.to_proto());
@@ -222,8 +222,8 @@ where
 pub trait Register<T, I, O>
 where
     T: Runnable<I, O>,
-    I: Serialize + Send + Sync,
-    O: DeserializeOwned + Send + Sync,
+    I: Serialize + Send + Sync + 'static,
+    O: DeserializeOwned + Send + Sync + 'static,
 {
     fn add_task_or_workflow(self, workflow: T) -> Self;
 }

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -207,22 +207,7 @@ where
     E: std::error::Error + Send + Sync + 'static,
 {
     fn add_task_or_workflow(mut self, workflow: Task<I, O, E>) -> Self {
-        let task_proto = workflow.to_proto(&workflow.name);
-        let workflow_proto = crate::clients::grpc::v1::workflows::CreateWorkflowVersionRequest {
-            name: workflow.name.clone(),
-            description: String::from(""),
-            version: String::from(""),
-            event_triggers: vec![],
-            cron_triggers: vec![],
-            tasks: vec![task_proto],
-            concurrency: None,
-            cron_input: None,
-            on_failure_task: None,
-            sticky: None,
-            default_priority: None,
-            concurrency_arr: vec![],
-            default_filters: vec![],
-        };
+        let workflow_proto = workflow.to_standalone_workflow_proto();
         self.workflows.push(workflow_proto);
 
         let fully_qualified_name = format!("{}:{}", workflow.name, workflow.name);

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -12,7 +12,8 @@ use crate::error::HatchetError;
 use crate::runnables::*;
 use crate::worker::action_listener::ActionListener;
 
-#[derive(typed_builder::TypedBuilder)]
+#[derive(derive_builder::Builder)]
+#[builder(pattern = "owned")]
 pub struct Worker {
     pub name: String,
     max_runs: i32,

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -5,22 +5,21 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::sync::mpsc;
 
-use crate::clients::hatchet::Hatchet;
 use crate::clients::grpc::v0::dispatcher;
 use crate::clients::grpc::v0::dispatcher::WorkerRegisterRequest;
+use crate::clients::hatchet::Hatchet;
 use crate::error::HatchetError;
 use crate::task::ExecutableTask;
 use crate::worker::action_listener::ActionListener;
 
-#[derive(derive_builder::Builder)]
-#[builder(pattern = "owned")]
+#[derive(typed_builder::TypedBuilder)]
 pub struct Worker {
     pub name: String,
     max_runs: i32,
     client: Hatchet,
-    #[builder(default = "Arc::new(Mutex::new(HashMap::new()))")]
+    #[builder(default = Arc::new(Mutex::new(HashMap::new())))]
     tasks: Arc<Mutex<HashMap<String, Arc<dyn ExecutableTask>>>>,
-    #[builder(default = "vec![]")]
+    #[builder(default = vec![])]
     workflows: Vec<crate::clients::grpc::v1::workflows::CreateWorkflowVersionRequest>,
 }
 
@@ -100,7 +99,6 @@ impl Worker {
     ///         workflow::<EmptyModel, EmptyModel>()
     ///         .name(String::from("my-workflow"))
     ///         .build()
-    ///         .unwrap()
     ///         .add_task(hatchet.task("my-task", async move |input: EmptyModel, _ctx: Context| -> anyhow::Result<EmptyModel> {
     ///             Ok(EmptyModel)
     ///         }))
@@ -108,8 +106,8 @@ impl Worker {
     ///
     ///     let mut worker = hatchet.worker()
     ///         .name(String::from("my-worker"))
+    ///         .max_runs(5)
     ///         .build()
-    ///         .unwrap()
     ///         .add_workflow(my_workflow);
     ///
     ///     worker.start().await.unwrap();

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -72,7 +72,7 @@ impl Worker {
     /// This will register the worker with Hatchet and start listening for assigned tasks.
     /// Use ctrl+c to stop the worker.
     ///
-    /// ```no_run
+    /// ```compile_fail
     /// use hatchet_sdk::{Context, Hatchet, EmptyModel, Runnable,Register};
     ///
     /// #[tokio::main]
@@ -83,6 +83,7 @@ impl Worker {
     ///         workflow::<EmptyModel, EmptyModel>()
     ///         .name(String::from("my-workflow"))
     ///         .build()
+    ///         .unwrap()
     ///         .add_task(hatchet.task("my-task", async move |input: EmptyModel, _ctx: Context| -> anyhow::Result<EmptyModel> {
     ///             Ok(EmptyModel)
     ///         }))
@@ -92,6 +93,7 @@ impl Worker {
     ///         .name(String::from("my-worker"))
     ///         .max_runs(5)
     ///         .build()
+    ///         .unwrap()
     ///         .add_task_or_workflow(my_workflow);
     ///
     ///     worker.start().await.unwrap();

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -221,7 +221,6 @@ where
 
 pub trait Register<T, I, O>
 where
-    T: Runnable<I, O>,
     I: Serialize + Send + Sync + 'static,
     O: DeserializeOwned + Send + Sync + 'static,
 {

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,22 +1,21 @@
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
-use crate::clients::hatchet::Hatchet;
 use crate::clients::grpc::v1::workflows::{
     CreateTaskOpts, CreateWorkflowVersionRequest, DefaultFilter as DefaultFilterProto,
 };
+use crate::clients::hatchet::Hatchet;
 use crate::error::HatchetError;
 use crate::features::runs::models::GetWorkflowRunResponse;
 use crate::features::runs::models::WorkflowStatus;
 use crate::task::{ExecutableTask, Task};
-use derive_builder::Builder;
+use typed_builder::TypedBuilder;
 
-#[derive(Clone, Builder)]
-#[builder(pattern = "owned")]
+#[derive(Clone, TypedBuilder)]
 pub struct Workflow<I, O> {
     pub(crate) name: String,
     client: Hatchet,
-    #[builder(default = "vec![]")]
+    #[builder(default = vec![])]
     pub(crate) executable_tasks: Vec<Box<dyn ExecutableTask>>,
     #[builder(default = String::from(""))]
     description: String,
@@ -24,15 +23,15 @@ pub struct Workflow<I, O> {
     version: String,
     #[builder(default = 1)]
     default_priority: i32,
-    #[builder(default = "vec![]")]
+    #[builder(default = vec![])]
     tasks: Vec<CreateTaskOpts>,
-    #[builder(default = "vec![]")]
+    #[builder(default = vec![])]
     on_events: Vec<String>,
-    #[builder(default = "vec![]")]
+    #[builder(default = vec![])]
     cron_triggers: Vec<String>,
-    #[builder(default = "vec![]")]
+    #[builder(default = vec![])]
     default_filters: Vec<DefaultFilter>,
-    #[builder(default = "std::marker::PhantomData")]
+    #[builder(default = std::marker::PhantomData)]
     _phantom: std::marker::PhantomData<(I, O)>,
 }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -109,15 +109,18 @@ where
             match workflow.run.status {
                 WorkflowStatus::Running => {}
                 WorkflowStatus::Completed => {
-                    let output_json = &workflow
-                        .tasks
-                        .last() // Get the output of the last task
-                        .ok_or(HatchetError::MissingTasks)?
-                        .output
-                        .as_ref()
-                        .ok_or(HatchetError::MissingOutput)?
-                        .to_string();
-                    let output: O = serde_json::from_str(&output_json)
+                    let mut task_outputs = serde_json::Map::new();
+
+                    for task in &workflow.tasks {
+                        if let (Some(action_id), Some(output)) = (&task.action_id, &task.output) {
+                            if let Some(task_name) = self.safely_get_action_name(action_id) {
+                                task_outputs.insert(task_name, output.clone());
+                            }
+                        }
+                    }
+
+                    let output_value = serde_json::Value::Object(task_outputs);
+                    let output: O = serde_json::from_value(output_value)
                         .map_err(|e| HatchetError::JsonDecodeError(e))?;
                     return Ok(output);
                 }
@@ -163,6 +166,10 @@ where
 
     async fn get_run(&self, run_id: &str) -> Result<GetWorkflowRunResponse, HatchetError> {
         self.client.workflow_rest_client.get(&run_id).await
+    }
+
+    fn safely_get_action_name(&self, action_id: &str) -> Option<String> {
+        action_id.split(':').nth(1).map(|s| s.to_string())
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ pub struct SimpleOutput {
     pub transformed_message: String,
 }
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum MyError {
     #[error("Test failed.")]
     Failure,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-use hatchet_sdk::worker::worker::WorkerBuilder;
+use hatchet_sdk::worker::worker::Worker;
 use hatchet_sdk::{Hatchet, HatchetError};
 
 mod common;
@@ -33,18 +33,16 @@ async fn test_run_returns_job_output() {
         .workflow::<SimpleInput, SimpleOutput>()
         .name(String::from("test-workflow"))
         .build()
-        .unwrap()
         .add_task(my_task)
         .unwrap();
 
     let workflow_clone = workflow.clone();
     let worker_handle = tokio::spawn(async move {
-        WorkerBuilder::default()
+        Worker::builder()
             .name(String::from("test-worker"))
             .client(hatchet.clone())
             .max_runs(5)
             .build()
-            .unwrap()
             .add_workflow(workflow_clone)
             .start()
             .await
@@ -95,7 +93,6 @@ async fn test_run_returns_error_if_job_fails() {
         .workflow::<SimpleInput, SimpleOutput>()
         .name(String::from("test-workflow"))
         .build()
-        .unwrap()
         .add_task(my_task)
         .unwrap();
 
@@ -106,7 +103,6 @@ async fn test_run_returns_error_if_job_fails() {
             .name(String::from("test-worker"))
             .max_runs(5)
             .build()
-            .unwrap()
             .add_workflow(workflow_clone)
             .start()
             .await
@@ -161,7 +157,6 @@ async fn test_dynamically_spawn_child_workflow() {
         .workflow::<hatchet_sdk::EmptyModel, serde_json::Value>()
         .name(String::from("child_workflow"))
         .build()
-        .unwrap()
         .add_task(child_task)
         .unwrap();
 
@@ -182,18 +177,16 @@ async fn test_dynamically_spawn_child_workflow() {
         .workflow::<hatchet_sdk::EmptyModel, serde_json::Value>()
         .name(String::from("parent-workflow"))
         .build()
-        .unwrap()
         .add_task(parent_task)
         .unwrap();
 
     let parent_workflow_clone = parent_workflow.clone();
     let worker_handle = tokio::spawn(async move {
-        hatchet_sdk::worker::worker::WorkerBuilder::default()
+        hatchet_sdk::worker::worker::Worker::builder()
             .name(String::from("test-worker"))
             .client(hatchet.clone())
             .max_runs(5)
             .build()
-            .unwrap()
             .add_workflow(parent_workflow_clone)
             .add_workflow(child_workflow_clone)
             .start()
@@ -254,7 +247,6 @@ async fn test_dag_workflow() {
         .workflow::<hatchet_sdk::EmptyModel, serde_json::Value>()
         .name(String::from("parent-workflow"))
         .build()
-        .unwrap()
         .add_task(parent_task)
         .unwrap()
         .add_task(child_task)
@@ -262,12 +254,11 @@ async fn test_dag_workflow() {
 
     let dag_workflow_clone = dag_workflow.clone();
     let worker_handle = tokio::spawn(async move {
-        hatchet_sdk::worker::worker::WorkerBuilder::default()
+        hatchet_sdk::worker::worker::Worker::builder()
             .name(String::from("test-worker"))
             .client(hatchet.clone())
             .max_runs(5)
             .build()
-            .unwrap()
             .add_workflow(dag_workflow_clone)
             .start()
             .await

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,5 @@
 use hatchet_sdk::worker::worker::Worker;
-use hatchet_sdk::{Hatchet, HatchetError};
+use hatchet_sdk::{Hatchet, HatchetError, Register, Runnable};
 
 mod common;
 use common::{MyError, SimpleInput, SimpleOutput};
@@ -19,7 +19,7 @@ async fn test_run_returns_job_output() {
         .await
         .unwrap();
 
-    let my_task = hatchet.task(
+    let mut task = hatchet.task(
         "step1",
         async move |input: SimpleInput,
                     _ctx: hatchet_sdk::Context|
@@ -29,21 +29,15 @@ async fn test_run_returns_job_output() {
             })
         },
     );
-    let mut workflow = hatchet
-        .workflow::<SimpleInput, SimpleOutput>()
-        .name(String::from("test-workflow"))
-        .build()
-        .add_task(my_task)
-        .unwrap();
 
-    let workflow_clone = workflow.clone();
-    let worker_handle = tokio::spawn(async move {
+    let task_clone = task.clone();
+    let worker_handle: tokio::task::JoinHandle<()> = tokio::spawn(async move {
         Worker::builder()
             .name(String::from("test-worker"))
             .client(hatchet.clone())
             .max_runs(5)
             .build()
-            .add_workflow(workflow_clone)
+            .add_task_or_workflow(task_clone)
             .start()
             .await
             .unwrap()
@@ -54,16 +48,15 @@ async fn test_run_returns_job_output() {
 
     assert_eq!(
         "uppercase",
-        workflow
-            .run(
-                SimpleInput {
-                    message: "UPPERCASE".to_string()
-                },
-                None
-            )
-            .await
-            .unwrap()
-            .transformed_message
+        task.run(
+            SimpleInput {
+                message: "UPPERCASE".to_string()
+            },
+            None
+        )
+        .await
+        .unwrap()
+        .transformed_message
     );
     worker_handle.abort()
 }
@@ -83,27 +76,21 @@ async fn test_run_returns_error_if_job_fails() {
         .await
         .unwrap();
 
-    let my_task = hatchet.task(
+    let mut task = hatchet.task(
         "step1",
         async move |_input: SimpleInput,
                     _ctx: hatchet_sdk::Context|
                     -> Result<SimpleOutput, MyError> { Err(MyError::Failure) },
     );
-    let mut workflow = hatchet
-        .workflow::<SimpleInput, SimpleOutput>()
-        .name(String::from("test-workflow"))
-        .build()
-        .add_task(my_task)
-        .unwrap();
 
-    let workflow_clone = workflow.clone();
+    let task_clone = task.clone();
     let worker_handle = tokio::spawn(async move {
         hatchet
             .worker()
             .name(String::from("test-worker"))
             .max_runs(5)
             .build()
-            .add_workflow(workflow_clone)
+            .add_task_or_workflow(task_clone)
             .start()
             .await
             .unwrap()
@@ -112,7 +99,7 @@ async fn test_run_returns_error_if_job_fails() {
     // Give worker time to register task
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
-    let output = workflow
+    let output = task
         .run(
             SimpleInput {
                 message: "UPPERCASE".to_string(),
@@ -144,7 +131,7 @@ async fn test_dynamically_spawn_child_workflow() {
         .await
         .unwrap();
 
-    let child_task = hatchet.task(
+    let mut child_task = hatchet.task(
         "child_task",
         async move |_input: hatchet_sdk::EmptyModel,
                     _ctx: hatchet_sdk::Context|
@@ -153,42 +140,26 @@ async fn test_dynamically_spawn_child_workflow() {
         },
     );
 
-    let mut child_workflow = hatchet
-        .workflow::<hatchet_sdk::EmptyModel, serde_json::Value>()
-        .name(String::from("child_workflow"))
-        .build()
-        .add_task(child_task)
-        .unwrap();
+    let child_task_clone = child_task.clone();
 
-    let child_workflow_clone = child_workflow.clone();
-
-    let parent_task = hatchet.task(
+    let mut parent_task = hatchet.task(
         "parent_task",
         async move |_input: hatchet_sdk::EmptyModel,
                     _ctx: hatchet_sdk::Context|
                     -> Result<serde_json::Value, MyError> {
-            Ok(child_workflow
-                .run(hatchet_sdk::EmptyModel, None)
-                .await
-                .unwrap())
+            Ok(child_task.run(hatchet_sdk::EmptyModel, None).await.unwrap())
         },
     );
-    let mut parent_workflow = hatchet
-        .workflow::<hatchet_sdk::EmptyModel, serde_json::Value>()
-        .name(String::from("parent-workflow"))
-        .build()
-        .add_task(parent_task)
-        .unwrap();
 
-    let parent_workflow_clone = parent_workflow.clone();
+    let task_clone = parent_task.clone();
     let worker_handle = tokio::spawn(async move {
         hatchet_sdk::worker::worker::Worker::builder()
             .name(String::from("test-worker"))
             .client(hatchet.clone())
             .max_runs(5)
             .build()
-            .add_workflow(parent_workflow_clone)
-            .add_workflow(child_workflow_clone)
+            .add_task_or_workflow(task_clone)
+            .add_task_or_workflow(child_task_clone)
             .start()
             .await
             .unwrap()
@@ -197,7 +168,7 @@ async fn test_dynamically_spawn_child_workflow() {
     // Give worker time to register task
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
-    let output = parent_workflow
+    let output = parent_task
         .run(hatchet_sdk::EmptyModel, None)
         .await
         .unwrap();
@@ -259,7 +230,7 @@ async fn test_dag_workflow() {
             .client(hatchet.clone())
             .max_runs(5)
             .build()
-            .add_workflow(dag_workflow_clone)
+            .add_task_or_workflow(dag_workflow_clone)
             .start()
             .await
             .unwrap()
@@ -272,7 +243,12 @@ async fn test_dag_workflow() {
 
     assert_eq!(
         "Parent said: \"I am your father\"",
-        output.unwrap().get("output").unwrap()
+        output
+            .unwrap()
+            .get("child_task")
+            .unwrap()
+            .get("output")
+            .unwrap()
     );
     worker_handle.abort()
 }


### PR DESCRIPTION
This moves the run and run_no_wait methods to a Runnable trait, allowing tasks to be run directly similar to workflows. Internally, the task registers a workflow with Hatchet with the same name as the task.

This change also makes improvements to the Task struct, adding the `derive_builder` macro so that new fields can be added in the future without a breaking change.