### PR TITLE
Add logging to workers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tonic = { version = "0.13", features = [
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
+log = "0.4.28"
 
 
 [build-dependencies]
@@ -39,6 +40,7 @@ tonic-build = { version = "0.13.1", features = ["prost"] }
 
 [dev-dependencies]
 dotenvy = "0.15.7"
+env_logger = "0.11.8"
 testcontainers = "0.25.0"
 
 [[example]]

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -1,4 +1,5 @@
 use hatchet_sdk::{Hatchet, Register, tokio};
+use log::LevelFilter;
 
 #[path = "simple.rs"]
 mod simple;
@@ -20,7 +21,9 @@ use dynamic_child_spawning::create_child_spawning_workflow;
 #[allow(dead_code)]
 async fn main() {
     dotenvy::dotenv().ok();
-    env_logger::init();
+    env_logger::Builder::new()
+        .filter_module("hatchet_sdk", LevelFilter::Debug)
+        .init();
 
     let hatchet = Hatchet::from_env().await.unwrap();
 

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -20,6 +20,8 @@ use dynamic_child_spawning::create_child_spawning_workflow;
 #[allow(dead_code)]
 async fn main() {
     dotenvy::dotenv().ok();
+    env_logger::init();
+
     let hatchet = Hatchet::from_env().await.unwrap();
 
     let simple_task = create_simple_task().await;

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -1,4 +1,3 @@
-use log;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -1,3 +1,4 @@
+use log;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -91,12 +92,14 @@ impl Worker {
     /// }
     /// ```
     pub async fn start(&mut self) -> Result<(), HatchetError> {
+        log::info!("🪓 STARTING HATCHET...");
         let mut actions = vec![];
         for workflow in &self.workflows {
             for task in &workflow.tasks {
                 actions.push(task.action.clone());
             }
         }
+        log::debug!("🪓 {} waiting for actions: {:?}", self.name, actions);
 
         let worker_id = Arc::new(
             Self::register_worker(
@@ -127,6 +130,7 @@ impl Worker {
 
         let worker_id_clone = worker_id.clone();
         tokio::spawn(async move {
+            log::debug!("🪓 starting action listener");
             action_listener
                 .lock()
                 .await
@@ -138,6 +142,7 @@ impl Worker {
             async {
                 const HEARTBEAT_INTERVAL: u64 = 4;
                 loop {
+                    log::debug!("🪓 sending heartbeat");
                     self.client.dispatcher_client.heartbeat(&worker_id).await?;
                     tokio::time::sleep(tokio::time::Duration::from_secs(HEARTBEAT_INTERVAL)).await;
                 }

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -92,14 +92,14 @@ impl Worker {
     /// }
     /// ```
     pub async fn start(&mut self) -> Result<(), HatchetError> {
-        log::info!("🪓 STARTING HATCHET...");
+        log::info!("STARTING HATCHET...");
         let mut actions = vec![];
         for workflow in &self.workflows {
             for task in &workflow.tasks {
                 actions.push(task.action.clone());
             }
         }
-        log::debug!("🪓 {} waiting for actions: {:?}", self.name, actions);
+        log::debug!("{} waiting for actions: {:?}", self.name, actions);
 
         let worker_id = Arc::new(
             Self::register_worker(
@@ -130,7 +130,7 @@ impl Worker {
 
         let worker_id_clone = worker_id.clone();
         tokio::spawn(async move {
-            log::debug!("🪓 starting action listener");
+            log::debug!("starting action listener");
             action_listener
                 .lock()
                 .await
@@ -142,7 +142,7 @@ impl Worker {
             async {
                 const HEARTBEAT_INTERVAL: u64 = 4;
                 loop {
-                    log::debug!("🪓 sending heartbeat");
+                    log::debug!("sending heartbeat");
                     self.client.dispatcher_client.heartbeat(&worker_id).await?;
                     tokio::time::sleep(tokio::time::Duration::from_secs(HEARTBEAT_INTERVAL)).await;
                 }


### PR DESCRIPTION
Use `log` crate to log messages from worker:
- heartbeats
- task starts/statuses