### PR TITLE
feat: add scheduling support (CronsClient, SchedulesClient)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 name: CI Checks
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,6 @@
 name: CI Checks
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 log = "0.4.28"
+chrono = { version = "0.4", features = ["serde"] }
+cron = "0.15"
 
 
 [build-dependencies]

--- a/src/clients/hatchet.rs
+++ b/src/clients/hatchet.rs
@@ -4,7 +4,10 @@ use std::time::Duration;
 use tonic::transport::{Channel, ClientTlsConfig};
 
 use super::grpc::{AdminClient, DispatcherClient, EventClient, WorkflowClient};
-use crate::{Configuration, HatchetConfig, HatchetError, RunsClient, TlsStrategy};
+use crate::{
+    Configuration, CronsClient, HatchetConfig, HatchetError, RunsClient, SchedulesClient,
+    TlsStrategy,
+};
 
 // Match the Go SDK's keepalive settings (pkg/client/client.go).
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
@@ -20,6 +23,8 @@ pub struct Hatchet {
     pub(crate) event_client: EventClient,
     pub(crate) admin_client: AdminClient,
     pub workflow_rest_client: RunsClient,
+    pub crons: CronsClient,
+    pub schedules: SchedulesClient,
 }
 
 impl Hatchet {
@@ -31,6 +36,8 @@ impl Hatchet {
         dispatcher_client: DispatcherClient,
         event_client: EventClient,
         workflow_rest_client: RunsClient,
+        crons: CronsClient,
+        schedules: SchedulesClient,
     ) -> Result<Self, HatchetError> {
         Ok(Self {
             server_url,
@@ -40,6 +47,8 @@ impl Hatchet {
             event_client,
             admin_client,
             workflow_rest_client,
+            crons,
+            schedules,
         })
     }
 
@@ -137,6 +146,9 @@ impl Hatchet {
         let workflow_rest_client =
             RunsClient::new(rest_configuration.clone(), dispatcher_client.clone());
 
+        let crons = CronsClient::new(rest_configuration.clone(), config.tenant_id.clone());
+        let schedules = SchedulesClient::new(rest_configuration.clone(), config.tenant_id.clone());
+
         Self::new(
             server_url.to_string(),
             config.api_token,
@@ -145,6 +157,8 @@ impl Hatchet {
             dispatcher_client,
             event_client,
             workflow_rest_client,
+            crons,
+            schedules,
         )
         .await
     }

--- a/src/clients/rest/features/crons.rs
+++ b/src/clients/rest/features/crons.rs
@@ -1,0 +1,226 @@
+use std::sync::Arc;
+
+use super::pagination::{PaginationResponse, hash_map_to_value};
+use crate::clients::rest::apis::workflow_api::{
+    cron_workflow_list, workflow_cron_delete, workflow_cron_get,
+};
+use crate::clients::rest::apis::workflow_run_api::cron_workflow_trigger_create;
+use crate::clients::rest::models::{
+    CronWorkflowList200Response, CronWorkflowTriggerCreate200Response,
+    CronWorkflowTriggerCreateRequest,
+};
+use crate::{Configuration, HatchetError};
+
+/// Client for managing cron workflow triggers. Accessed via [`Hatchet::crons`](crate::Hatchet).
+///
+/// Supports both 5-field (`* * * * *`) and 6-field (`* * * * * *`) cron expressions.
+/// Requires a token with a `sub` (tenant ID) claim.
+#[derive(Clone, Debug)]
+pub struct CronsClient {
+    configuration: Arc<Configuration>,
+    tenant_id: Option<String>,
+}
+
+impl CronsClient {
+    pub(crate) fn new(configuration: Arc<Configuration>, tenant_id: Option<String>) -> Self {
+        Self {
+            configuration,
+            tenant_id,
+        }
+    }
+
+    fn tenant_id(&self) -> Result<&str, HatchetError> {
+        self.tenant_id
+            .as_deref()
+            .ok_or_else(|| HatchetError::MissingTokenField("sub"))
+    }
+
+    /// Create a cron trigger for the given workflow. Validates the expression client-side before calling the API.
+    pub async fn create(
+        &self,
+        workflow_name: &str,
+        opts: CreateCronOpts,
+    ) -> Result<CronTrigger, HatchetError> {
+        // cron crate requires seconds field; prepend "0" for 5-field expressions
+        let normalized = if opts.expression.split_whitespace().count() == 5 {
+            format!("0 {}", opts.expression)
+        } else {
+            opts.expression.clone()
+        };
+        normalized
+            .parse::<cron::Schedule>()
+            .map_err(|_| HatchetError::InvalidCronExpression(opts.expression.clone()))?;
+
+        let request = CronWorkflowTriggerCreateRequest {
+            input: opts.input,
+            additional_metadata: opts
+                .additional_metadata
+                .unwrap_or_else(|| serde_json::json!({})),
+            cron_name: opts.name,
+            cron_expression: opts.expression,
+            priority: opts.priority,
+        };
+
+        let tenant = self.tenant_id()?;
+        cron_workflow_trigger_create(&self.configuration, tenant, workflow_name, request)
+            .await
+            .map(Into::into)
+            .map_err(HatchetError::from_rest)
+    }
+
+    /// Retrieve a cron trigger by ID.
+    pub async fn get(&self, cron_id: &str) -> Result<CronTrigger, HatchetError> {
+        let tenant = self.tenant_id()?;
+        workflow_cron_get(&self.configuration, tenant, cron_id)
+            .await
+            .map(Into::into)
+            .map_err(HatchetError::from_rest)
+    }
+
+    /// List cron triggers, optionally filtered by workflow, name, or metadata.
+    pub async fn list(&self, opts: ListCronsOpts) -> Result<CronTriggerList, HatchetError> {
+        let tenant = self.tenant_id()?;
+        cron_workflow_list(
+            &self.configuration,
+            tenant,
+            opts.offset,
+            opts.limit,
+            opts.workflow_id.as_deref(),
+            opts.workflow_name.as_deref(),
+            opts.cron_name.as_deref(),
+            opts.additional_metadata,
+            opts.order_by_field.as_deref(),
+            opts.order_by_direction.as_deref(),
+        )
+        .await
+        .map(Into::into)
+        .map_err(HatchetError::from_rest)
+    }
+
+    /// Delete a cron trigger by ID.
+    pub async fn delete(&self, cron_id: &str) -> Result<(), HatchetError> {
+        let tenant = self.tenant_id()?;
+        workflow_cron_delete(&self.configuration, tenant, cron_id)
+            .await
+            .map_err(HatchetError::from_rest)
+    }
+}
+
+/// Options for creating a cron trigger via [`CronsClient::create`].
+#[derive(Clone, Debug)]
+pub struct CreateCronOpts {
+    pub name: String,
+    pub expression: String,
+    pub input: serde_json::Value,
+    pub additional_metadata: Option<serde_json::Value>,
+    pub priority: Option<i32>,
+}
+
+/// Filter and pagination options for [`CronsClient::list`].
+#[derive(Clone, Debug, Default)]
+pub struct ListCronsOpts {
+    pub offset: Option<i64>,
+    pub limit: Option<i64>,
+    pub workflow_id: Option<String>,
+    pub workflow_name: Option<String>,
+    pub cron_name: Option<String>,
+    pub additional_metadata: Option<Vec<String>>,
+    pub order_by_field: Option<String>,
+    pub order_by_direction: Option<String>,
+}
+
+/// A cron workflow trigger returned by the Hatchet API.
+#[derive(Clone, Debug)]
+pub struct CronTrigger {
+    pub metadata_id: String,
+    pub cron: String,
+    pub name: Option<String>,
+    pub workflow_id: String,
+    pub workflow_name: String,
+    pub input: serde_json::Value,
+    pub additional_metadata: serde_json::Value,
+    pub enabled: bool,
+    pub priority: Option<i32>,
+}
+
+impl From<CronWorkflowTriggerCreate200Response> for CronTrigger {
+    fn from(r: CronWorkflowTriggerCreate200Response) -> Self {
+        Self {
+            metadata_id: r.metadata.id,
+            cron: r.cron,
+            name: r.name,
+            workflow_id: r.workflow_id,
+            workflow_name: r.workflow_name,
+            input: hash_map_to_value(r.input),
+            additional_metadata: hash_map_to_value(r.additional_metadata),
+            enabled: r.enabled,
+            priority: r.priority,
+        }
+    }
+}
+
+/// Paginated list of cron triggers returned by [`CronsClient::list`].
+#[derive(Clone, Debug)]
+pub struct CronTriggerList {
+    pub rows: Vec<CronTrigger>,
+    pub pagination: Option<PaginationResponse>,
+}
+
+impl From<CronWorkflowList200Response> for CronTriggerList {
+    fn from(r: CronWorkflowList200Response) -> Self {
+        Self {
+            rows: r
+                .rows
+                .unwrap_or_default()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            pagination: r.pagination.map(Into::into),
+        }
+    }
+}
+
+/// Optional parameters for [`Task::cron`](crate::Task::cron) and [`Workflow::cron`](crate::Workflow::cron).
+#[derive(Clone, Debug, Default)]
+pub struct CronOptions {
+    pub additional_metadata: Option<serde_json::Value>,
+    pub priority: Option<i32>,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_six_field_cron_expression_parses() {
+        assert!("0 */2 * * * *".parse::<cron::Schedule>().is_ok());
+    }
+
+    #[test]
+    fn test_five_field_cron_with_prepended_seconds_parses() {
+        let five_field = "*/2 * * * *";
+        let normalized = format!("0 {}", five_field);
+        assert!(normalized.parse::<cron::Schedule>().is_ok());
+    }
+
+    #[test]
+    fn test_invalid_cron_expression_fails() {
+        assert!("not a cron".parse::<cron::Schedule>().is_err());
+    }
+
+    #[test]
+    fn test_missing_tenant_returns_error() {
+        let client = super::CronsClient::new(
+            std::sync::Arc::new(crate::Configuration {
+                base_path: String::new(),
+                client: reqwest::Client::new(),
+                basic_auth: None,
+                oauth_access_token: None,
+                bearer_access_token: None,
+                user_agent: None,
+                api_key: None,
+            }),
+            None,
+        );
+        let err = client.tenant_id().unwrap_err();
+        assert!(matches!(err, crate::HatchetError::MissingTokenField("sub")));
+    }
+}

--- a/src/clients/rest/features/mod.rs
+++ b/src/clients/rest/features/mod.rs
@@ -1,5 +1,10 @@
+pub mod crons;
+pub mod pagination;
 pub mod runs;
+pub mod schedules;
 
+pub use crons::CronsClient;
 pub use runs::RunsClient;
 pub use runs::models::GetWorkflowRunResponse;
 pub use runs::models::WorkflowStatus;
+pub use schedules::SchedulesClient;

--- a/src/clients/rest/features/pagination.rs
+++ b/src/clients/rest/features/pagination.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use crate::clients::rest::models::V1TaskEventList200ResponsePagination;
+
+/// Converts an auto-generated `Option<HashMap<String, Value>>` to a flat `Value::Object`,
+/// defaulting to `{}`. Used by feature client `From` impls.
+pub(super) fn hash_map_to_value(
+    value: Option<HashMap<String, serde_json::Value>>,
+) -> serde_json::Value {
+    value
+        .and_then(|map| serde_json::to_value(map).ok())
+        .unwrap_or_else(|| serde_json::json!({}))
+}
+
+/// Pagination metadata returned by list endpoints.
+#[derive(Clone, Debug)]
+pub struct PaginationResponse {
+    pub current_page: Option<i64>,
+    pub num_pages: Option<i64>,
+    pub next_page: Option<i64>,
+}
+
+impl From<Box<V1TaskEventList200ResponsePagination>> for PaginationResponse {
+    fn from(response: Box<V1TaskEventList200ResponsePagination>) -> Self {
+        Self {
+            current_page: response.current_page,
+            num_pages: response.num_pages,
+            next_page: response.next_page,
+        }
+    }
+}

--- a/src/clients/rest/features/runs.rs
+++ b/src/clients/rest/features/runs.rs
@@ -36,10 +36,10 @@ impl RunsClient {
     /// }
     /// ```
     pub async fn get(&self, workflow_run_id: &str) -> Result<GetWorkflowRunResponse, HatchetError> {
-        let response = v1_workflow_run_get(&self.configuration, workflow_run_id)
+        v1_workflow_run_get(&self.configuration, workflow_run_id)
             .await
-            .map_err(|e| HatchetError::RestApiError(e.to_string()))?;
-        Ok(GetWorkflowRunResponse::from(response))
+            .map(GetWorkflowRunResponse::from)
+            .map_err(HatchetError::from_rest)
     }
 
     /// Subscribe to stream events for a workflow run. Returns an async Stream of byte chunks

--- a/src/clients/rest/features/schedules.rs
+++ b/src/clients/rest/features/schedules.rs
@@ -1,0 +1,185 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+
+use super::pagination::{PaginationResponse, hash_map_to_value};
+use crate::clients::rest::apis::workflow_api::{
+    workflow_scheduled_delete, workflow_scheduled_get, workflow_scheduled_list,
+};
+use crate::clients::rest::apis::workflow_run_api::scheduled_workflow_run_create;
+use crate::clients::rest::models::{
+    ScheduledWorkflowRunCreate200Response, ScheduledWorkflowRunCreateRequest,
+    WorkflowScheduledList200Response,
+};
+use crate::{Configuration, HatchetError};
+
+/// Client for managing scheduled (one-time) workflow runs. Accessed via [`Hatchet::schedules`](crate::Hatchet).
+///
+/// Requires a token with a `sub` (tenant ID) claim.
+#[derive(Clone, Debug)]
+pub struct SchedulesClient {
+    configuration: Arc<Configuration>,
+    tenant_id: Option<String>,
+}
+
+impl SchedulesClient {
+    pub(crate) fn new(configuration: Arc<Configuration>, tenant_id: Option<String>) -> Self {
+        Self {
+            configuration,
+            tenant_id,
+        }
+    }
+
+    fn tenant_id(&self) -> Result<&str, HatchetError> {
+        self.tenant_id
+            .as_deref()
+            .ok_or_else(|| HatchetError::MissingTokenField("sub"))
+    }
+
+    /// Schedule a workflow to run at a specific future time.
+    pub async fn create(
+        &self,
+        workflow_name: &str,
+        opts: CreateScheduleOpts,
+    ) -> Result<ScheduledRun, HatchetError> {
+        let tenant = self.tenant_id()?;
+        let request = ScheduledWorkflowRunCreateRequest {
+            input: opts.input,
+            additional_metadata: opts
+                .additional_metadata
+                .unwrap_or_else(|| serde_json::json!({})),
+            trigger_at: opts.trigger_at.to_rfc3339(),
+            priority: opts.priority,
+        };
+
+        scheduled_workflow_run_create(&self.configuration, tenant, workflow_name, request)
+            .await
+            .map(Into::into)
+            .map_err(HatchetError::from_rest)
+    }
+
+    /// Retrieve a scheduled run by ID.
+    pub async fn get(&self, scheduled_id: &str) -> Result<ScheduledRun, HatchetError> {
+        let tenant = self.tenant_id()?;
+        workflow_scheduled_get(&self.configuration, tenant, scheduled_id)
+            .await
+            .map(Into::into)
+            .map_err(HatchetError::from_rest)
+    }
+
+    /// List scheduled runs, optionally filtered by workflow, status, or metadata.
+    pub async fn list(&self, opts: ListSchedulesOpts) -> Result<ScheduledRunList, HatchetError> {
+        let tenant = self.tenant_id()?;
+        workflow_scheduled_list(
+            &self.configuration,
+            tenant,
+            opts.offset,
+            opts.limit,
+            opts.order_by_field.as_deref(),
+            opts.order_by_direction.as_deref(),
+            opts.workflow_id.as_deref(),
+            opts.parent_workflow_run_id.as_deref(),
+            opts.parent_task_run_external_id.as_deref(),
+            opts.additional_metadata,
+            opts.statuses,
+        )
+        .await
+        .map(Into::into)
+        .map_err(HatchetError::from_rest)
+    }
+
+    /// Delete a scheduled run by ID.
+    pub async fn delete(&self, scheduled_id: &str) -> Result<(), HatchetError> {
+        let tenant = self.tenant_id()?;
+        workflow_scheduled_delete(&self.configuration, tenant, scheduled_id)
+            .await
+            .map_err(HatchetError::from_rest)
+    }
+}
+
+/// Options for creating a scheduled run via [`SchedulesClient::create`].
+#[derive(Clone, Debug)]
+pub struct CreateScheduleOpts {
+    pub trigger_at: DateTime<Utc>,
+    pub input: serde_json::Value,
+    pub additional_metadata: Option<serde_json::Value>,
+    pub priority: Option<i32>,
+}
+
+/// Filter and pagination options for [`SchedulesClient::list`].
+#[derive(Clone, Debug, Default)]
+pub struct ListSchedulesOpts {
+    pub offset: Option<i64>,
+    pub limit: Option<i64>,
+    pub workflow_id: Option<String>,
+    pub parent_workflow_run_id: Option<String>,
+    pub parent_task_run_external_id: Option<String>,
+    pub additional_metadata: Option<Vec<String>>,
+    pub statuses: Option<Vec<String>>,
+    pub order_by_field: Option<String>,
+    pub order_by_direction: Option<String>,
+}
+
+/// A scheduled workflow run returned by the Hatchet API. The run will be enqueued at `trigger_at`.
+#[derive(Clone, Debug)]
+pub struct ScheduledRun {
+    pub metadata_id: String,
+    pub trigger_at: String,
+    pub workflow_id: String,
+    pub workflow_name: String,
+    pub workflow_version_id: String,
+    pub input: serde_json::Value,
+    pub additional_metadata: serde_json::Value,
+    pub workflow_run_id: Option<String>,
+    pub workflow_run_status: Option<String>,
+    pub priority: Option<i32>,
+}
+
+impl From<ScheduledWorkflowRunCreate200Response> for ScheduledRun {
+    fn from(r: ScheduledWorkflowRunCreate200Response) -> Self {
+        Self {
+            metadata_id: r.metadata.id,
+            trigger_at: r.trigger_at,
+            workflow_id: r.workflow_id,
+            workflow_name: r.workflow_name,
+            workflow_version_id: r.workflow_version_id,
+            input: hash_map_to_value(r.input),
+            additional_metadata: hash_map_to_value(r.additional_metadata),
+            workflow_run_id: r.workflow_run_id.map(|id| id.to_string()),
+            workflow_run_status: r.workflow_run_status.and_then(|status| {
+                serde_json::to_value(status)
+                    .ok()
+                    .and_then(|v| v.as_str().map(str::to_string))
+            }),
+            priority: r.priority,
+        }
+    }
+}
+
+/// Paginated list of scheduled runs returned by [`SchedulesClient::list`].
+#[derive(Clone, Debug)]
+pub struct ScheduledRunList {
+    pub rows: Vec<ScheduledRun>,
+    pub pagination: Option<PaginationResponse>,
+}
+
+impl From<WorkflowScheduledList200Response> for ScheduledRunList {
+    fn from(r: WorkflowScheduledList200Response) -> Self {
+        Self {
+            rows: r
+                .rows
+                .unwrap_or_default()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            pagination: r.pagination.map(Into::into),
+        }
+    }
+}
+
+/// Optional parameters for [`Task::schedule`](crate::Task::schedule) and [`Workflow::schedule`](crate::Workflow::schedule).
+#[derive(Clone, Debug, Default)]
+pub struct ScheduleOptions {
+    pub additional_metadata: Option<serde_json::Value>,
+    pub priority: Option<i32>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ pub(crate) struct HatchetConfig {
     pub(crate) grpc_address: String,
     pub(crate) server_url: String,
     pub(crate) tls_strategy: TlsStrategy,
+    pub(crate) tenant_id: Option<String>,
 }
 
 impl HatchetConfig {
@@ -28,7 +29,7 @@ impl HatchetConfig {
 
         let payload_json = Self::decode_token(parts[1])?;
 
-        let (grpc_address, server_url) = Self::parse_token(payload_json)?;
+        let (grpc_address, server_url, tenant_id) = Self::parse_token(payload_json)?;
 
         let strategy = match tls_strategy {
             "none" => TlsStrategy::None,
@@ -38,9 +39,10 @@ impl HatchetConfig {
 
         Ok(Self {
             api_token: token.to_string(),
-            grpc_address: grpc_address.to_string(),
-            server_url: server_url.to_string(),
+            grpc_address,
+            server_url,
             tls_strategy: strategy,
+            tenant_id,
         })
     }
 
@@ -61,7 +63,9 @@ impl HatchetConfig {
         Ok(payload_json)
     }
 
-    fn parse_token(payload_json: serde_json::Value) -> Result<(String, String), HatchetError> {
+    fn parse_token(
+        payload_json: serde_json::Value,
+    ) -> Result<(String, String, Option<String>), HatchetError> {
         let grpc_address = payload_json
             .get("grpc_broadcast_address")
             .and_then(|v| v.as_str())
@@ -72,7 +76,12 @@ impl HatchetConfig {
             .and_then(|v| v.as_str())
             .ok_or(HatchetError::MissingTokenField("server_url"))?;
 
-        Ok((grpc_address.to_string(), server_url.to_string()))
+        let tenant_id = payload_json
+            .get("sub")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        Ok((grpc_address.to_string(), server_url.to_string(), tenant_id))
     }
 }
 
@@ -96,16 +105,36 @@ mod tests {
 
     #[test]
     fn test_token_decoded_into_config() {
-        let payload = "eyJzZXJ2ZXJfdXJsIjoiaHR0cHM6Ly9oYXRjaGV0LmNvbSIsImdycGNfYnJvYWRjYXN0X2FkZHJlc3MiOiJlbmdpbmUuaGF0Y2hldC5jb20ifQ";
+        let payload = "eyJzZXJ2ZXJfdXJsIjoiaHR0cHM6Ly9oYXRjaGV0LmNvbSIsImdycGNfYnJvYWRjYXN0X2FkZHJlc3MiOiJlbmdpbmUuaGF0Y2hldC5jb20iLCJzdWIiOiJ0ZXN0LXRlbmFudCJ9";
         let token = format!("header.{}.sig", payload);
         let config = HatchetConfig::new(&token, "tls").unwrap();
         assert_eq!(config.server_url, "https://hatchet.com");
         assert_eq!(config.grpc_address, "engine.hatchet.com");
+        assert_eq!(config.tenant_id, Some("test-tenant".to_string()));
+    }
+
+    #[test]
+    fn test_tenant_id_extracted_from_token() {
+        let payload = "eyJzZXJ2ZXJfdXJsIjoiaHR0cHM6Ly9oYXRjaGV0LmNvbSIsImdycGNfYnJvYWRjYXN0X2FkZHJlc3MiOiJlbmdpbmUuaGF0Y2hldC5jb20iLCJzdWIiOiI3MDdkMDg1NS04MGFiLTRlMWYtYTE1Ni1mMWM0NTQ2Y2JmNTIifQ";
+        let token = format!("header.{}.sig", payload);
+        let config = HatchetConfig::new(&token, "tls").unwrap();
+        assert_eq!(
+            config.tenant_id,
+            Some("707d0855-80ab-4e1f-a156-f1c4546cbf52".to_string())
+        );
+    }
+
+    #[test]
+    fn test_missing_sub_claim_returns_none_tenant() {
+        let payload = "eyJzZXJ2ZXJfdXJsIjoiaHR0cHM6Ly9oYXRjaGV0LmNvbSIsImdycGNfYnJvYWRjYXN0X2FkZHJlc3MiOiJlbmdpbmUuaGF0Y2hldC5jb20ifQ";
+        let token = format!("header.{}.sig", payload);
+        let config = HatchetConfig::new(&token, "tls").unwrap();
+        assert_eq!(config.tenant_id, None);
     }
 
     #[test]
     fn test_invalid_tls_strategy_raises_error() {
-        let payload = "eyJzZXJ2ZXJfdXJsIjoiaHR0cHM6Ly9oYXRjaGV0LmNvbSIsImdycGNfYnJvYWRjYXN0X2FkZHJlc3MiOiJlbmdpbmUuaGF0Y2hldC5jb20ifQ";
+        let payload = "eyJzZXJ2ZXJfdXJsIjoiaHR0cHM6Ly9oYXRjaGV0LmNvbSIsImdycGNfYnJvYWRjYXN0X2FkZHJlc3MiOiJlbmdpbmUuaGF0Y2hldC5jb20iLCJzdWIiOiJ0ZXN0LXRlbmFudCJ9";
         let token = format!("header.{}.sig", payload);
         let config = HatchetConfig::new(&token, "bad_strategy");
         assert!(matches!(config, Err(HatchetError::InvalidTlsStrategy(_))));

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,10 +46,18 @@ pub enum HatchetError {
     CryptoProvider,
     #[error("{0}")]
     RestApiError(String),
+    #[error("Invalid cron expression: {0}")]
+    InvalidCronExpression(String),
     #[error("Error sending message to dispatcher: {0}")]
     DispatchError(String),
     #[error("Error sending stream event: {0}")]
     StreamError(String),
     #[error("Internal error: {0}")]
     InternalError(String),
+}
+
+impl HatchetError {
+    pub(crate) fn from_rest<E: std::fmt::Display>(error: E) -> Self {
+        Self::RestApiError(error.to_string())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,16 @@ pub mod runnables;
 pub mod utils;
 pub mod worker;
 
-pub use clients::RunsClient;
 pub use clients::hatchet::Hatchet;
+pub use clients::rest::features::crons::{
+    CreateCronOpts, CronOptions, CronTrigger, CronTriggerList, ListCronsOpts,
+};
+pub use clients::rest::features::pagination::PaginationResponse;
+pub use clients::rest::features::schedules::{
+    CreateScheduleOpts, ListSchedulesOpts, ScheduleOptions, ScheduledRun, ScheduledRunList,
+};
 pub(crate) use clients::{Configuration, GetWorkflowRunResponse, WorkflowStatus};
+pub use clients::{CronsClient, RunsClient, SchedulesClient};
 pub(crate) use config::{HatchetConfig, TlsStrategy};
 pub use context::Context;
 pub use error::HatchetError;
@@ -21,4 +28,4 @@ pub use worker::{Register, Worker};
 pub mod anyhow {
     pub use anyhow::{Error, Result};
 }
-pub use {serde, serde_json, tokio};
+pub use {chrono, serde, serde_json, tokio};

--- a/src/runnables/task.rs
+++ b/src/runnables/task.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 use super::workflow::DefaultFilter;
 use super::{ExtractRunnableOutput, TriggerWorkflowOptions};
 use crate::clients::grpc::v1::workflows::{CreateTaskOpts, CreateWorkflowVersionRequest};
+use crate::clients::rest::features::crons::{CreateCronOpts, CronOptions, CronTrigger};
+use crate::clients::rest::features::schedules::{
+    CreateScheduleOpts, ScheduleOptions, ScheduledRun,
+};
 use crate::utils::duration_to_expr;
 use crate::{Context, GetWorkflowRunResponse, Hatchet, HatchetError};
 
@@ -166,6 +170,56 @@ where
                 .as_ref()
                 .map(|value| serde_json::to_vec(value).expect("must be serializable")),
         }
+    }
+
+    /// Schedule this task's workflow to run at a specific future time.
+    /// See [`SchedulesClient::create`](crate::SchedulesClient::create) for the underlying API.
+    pub async fn schedule(
+        &self,
+        trigger_at: chrono::DateTime<chrono::Utc>,
+        input: &I,
+        options: Option<&ScheduleOptions>,
+    ) -> Result<ScheduledRun, HatchetError> {
+        let input_json =
+            serde_json::to_value(input).map_err(|e| HatchetError::JsonEncode(e.to_string()))?;
+        self.client
+            .schedules
+            .create(
+                &self.name.to_lowercase(),
+                CreateScheduleOpts {
+                    trigger_at,
+                    input: input_json,
+                    additional_metadata: options.and_then(|o| o.additional_metadata.clone()),
+                    priority: options.and_then(|o| o.priority),
+                },
+            )
+            .await
+    }
+
+    /// Create a recurring cron trigger for this task's workflow.
+    /// See [`CronsClient::create`](crate::CronsClient::create) for the underlying API.
+    pub async fn cron(
+        &self,
+        name: &str,
+        expression: &str,
+        input: &I,
+        options: Option<&CronOptions>,
+    ) -> Result<CronTrigger, HatchetError> {
+        let input_json =
+            serde_json::to_value(input).map_err(|e| HatchetError::JsonEncode(e.to_string()))?;
+        self.client
+            .crons
+            .create(
+                &self.name.to_lowercase(),
+                CreateCronOpts {
+                    name: name.to_string(),
+                    expression: expression.to_string(),
+                    input: input_json,
+                    additional_metadata: options.and_then(|o| o.additional_metadata.clone()),
+                    priority: options.and_then(|o| o.priority),
+                },
+            )
+            .await
     }
 
     async fn trigger(

--- a/src/runnables/workflow.rs
+++ b/src/runnables/workflow.rs
@@ -6,6 +6,10 @@ use super::{ExecutableTask, ExtractRunnableOutput, Task, TriggerWorkflowOptions}
 use crate::clients::grpc::v1::workflows::{
     CreateTaskOpts, CreateWorkflowVersionRequest, DefaultFilter as DefaultFilterProto,
 };
+use crate::clients::rest::features::crons::{CreateCronOpts, CronOptions, CronTrigger};
+use crate::clients::rest::features::schedules::{
+    CreateScheduleOpts, ScheduleOptions, ScheduledRun,
+};
 use crate::{GetWorkflowRunResponse, Hatchet, HatchetError};
 
 /// A workflow is a collection of tasks that can be executed by a worker, often forming a directed acyclic graph (DAG).
@@ -85,6 +89,56 @@ where
                 .as_ref()
                 .map(|value| serde_json::to_vec(value).expect("must be serializable")),
         }
+    }
+
+    /// Schedule this workflow to run at a specific future time.
+    /// See [`SchedulesClient::create`](crate::SchedulesClient::create) for the underlying API.
+    pub async fn schedule(
+        &self,
+        trigger_at: chrono::DateTime<chrono::Utc>,
+        input: &I,
+        options: Option<&ScheduleOptions>,
+    ) -> Result<ScheduledRun, HatchetError> {
+        let input_json =
+            serde_json::to_value(input).map_err(|e| HatchetError::JsonEncode(e.to_string()))?;
+        self.client
+            .schedules
+            .create(
+                &self.name.to_lowercase(),
+                CreateScheduleOpts {
+                    trigger_at,
+                    input: input_json,
+                    additional_metadata: options.and_then(|o| o.additional_metadata.clone()),
+                    priority: options.and_then(|o| o.priority),
+                },
+            )
+            .await
+    }
+
+    /// Create a recurring cron trigger for this workflow.
+    /// See [`CronsClient::create`](crate::CronsClient::create) for the underlying API.
+    pub async fn cron(
+        &self,
+        name: &str,
+        expression: &str,
+        input: &I,
+        options: Option<&CronOptions>,
+    ) -> Result<CronTrigger, HatchetError> {
+        let input_json =
+            serde_json::to_value(input).map_err(|e| HatchetError::JsonEncode(e.to_string()))?;
+        self.client
+            .crons
+            .create(
+                &self.name.to_lowercase(),
+                CreateCronOpts {
+                    name: name.to_string(),
+                    expression: expression.to_string(),
+                    input: input_json,
+                    additional_metadata: options.and_then(|o| o.additional_metadata.clone()),
+                    priority: options.and_then(|o| o.priority),
+                },
+            )
+            .await
     }
 
     async fn trigger(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,7 @@ use futures::StreamExt;
 use hatchet_sdk::{HatchetError, Runnable};
 
 mod common;
-use common::{SimpleInput, SimpleOutput, TestHarness};
+use common::{SimpleInput, SimpleOutput, TestHarness, hatchet_version_at_least};
 
 #[tokio::test]
 async fn test_run_returns_job_output() {
@@ -296,4 +296,255 @@ async fn test_workflow_with_input_json_schema() {
         .unwrap();
 
     assert_eq!(10, output.value);
+}
+
+#[tokio::test]
+async fn test_cron_lifecycle() {
+    let t = TestHarness::new("cron-lifecycle").await;
+    let task = t.simple_task("task");
+    let _worker = t.spawn_worker_for_task(&task).await;
+
+    let task_name = t.prefixed("task");
+    let cron = t
+        .hatchet
+        .crons
+        .create(
+            &task_name,
+            hatchet_sdk::CreateCronOpts {
+                name: t.prefixed("hourly"),
+                expression: "0 * * * *".to_string(),
+                input: serde_json::json!({"message": "cron-input"}),
+                additional_metadata: Some(serde_json::json!({"env": "test"})),
+                priority: Some(2),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(cron.enabled);
+    assert_eq!(cron.priority, Some(2));
+
+    let fetched = t.hatchet.crons.get(&cron.metadata_id).await.unwrap();
+    assert_eq!(fetched.metadata_id, cron.metadata_id);
+
+    let list = t.hatchet.crons.list(Default::default()).await.unwrap();
+    assert!(list.rows.iter().any(|r| r.metadata_id == cron.metadata_id));
+
+    t.hatchet.crons.delete(&cron.metadata_id).await.unwrap();
+
+    let after_delete = t.hatchet.crons.get(&cron.metadata_id).await;
+    assert!(after_delete.is_err());
+
+    let list_after = t.hatchet.crons.list(Default::default()).await.unwrap();
+    assert!(
+        !list_after
+            .rows
+            .iter()
+            .any(|r| r.metadata_id == cron.metadata_id)
+    );
+}
+
+#[tokio::test]
+async fn test_schedule_lifecycle() {
+    let t = TestHarness::new("schedule-lifecycle").await;
+    let task = t.simple_task("task");
+    let _worker = t.spawn_worker_for_task(&task).await;
+
+    let task_name = t.prefixed("task");
+    let trigger_at = hatchet_sdk::chrono::Utc::now() + hatchet_sdk::chrono::Duration::hours(1);
+    let scheduled = t
+        .hatchet
+        .schedules
+        .create(
+            &task_name,
+            hatchet_sdk::CreateScheduleOpts {
+                trigger_at,
+                input: serde_json::json!({"message": "scheduled-input"}),
+                additional_metadata: Some(serde_json::json!({"env": "test"})),
+                priority: Some(3),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(!scheduled.metadata_id.is_empty());
+    assert_eq!(scheduled.priority, Some(3));
+
+    // schedules.get() returns 500 on Hatchet < v0.75
+    if hatchet_version_at_least(0, 75) {
+        let fetched = t
+            .hatchet
+            .schedules
+            .get(&scheduled.metadata_id)
+            .await
+            .unwrap();
+        assert_eq!(fetched.metadata_id, scheduled.metadata_id);
+    }
+
+    let list = t.hatchet.schedules.list(Default::default()).await.unwrap();
+    assert!(
+        list.rows
+            .iter()
+            .any(|r| r.metadata_id == scheduled.metadata_id)
+    );
+
+    t.hatchet
+        .schedules
+        .delete(&scheduled.metadata_id)
+        .await
+        .unwrap();
+
+    if hatchet_version_at_least(0, 75) {
+        let after_delete = t.hatchet.schedules.get(&scheduled.metadata_id).await;
+        assert!(after_delete.is_err());
+    }
+
+    let list_after = t.hatchet.schedules.list(Default::default()).await.unwrap();
+    assert!(
+        !list_after
+            .rows
+            .iter()
+            .any(|r| r.metadata_id == scheduled.metadata_id)
+    );
+}
+
+#[tokio::test]
+async fn test_task_cron_convenience() {
+    let t = TestHarness::new("cron-conv").await;
+    let task = t.simple_task("task");
+    let _worker = t.spawn_worker_for_task(&task).await;
+
+    let cron = task
+        .cron(
+            &t.prefixed("every5"),
+            "*/5 * * * *",
+            &SimpleInput {
+                message: "via-convenience".to_string(),
+            },
+            Some(&hatchet_sdk::CronOptions {
+                additional_metadata: Some(serde_json::json!({"source": "convenience"})),
+                priority: Some(1),
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(cron.priority, Some(1));
+
+    let list = t.hatchet.crons.list(Default::default()).await.unwrap();
+    assert!(list.rows.iter().any(|r| r.metadata_id == cron.metadata_id));
+
+    t.hatchet.crons.delete(&cron.metadata_id).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_task_schedule_convenience() {
+    let t = TestHarness::new("sched-conv").await;
+    let task = t.simple_task("task");
+    let _worker = t.spawn_worker_for_task(&task).await;
+
+    let trigger_at = hatchet_sdk::chrono::Utc::now() + hatchet_sdk::chrono::Duration::hours(2);
+    let scheduled = task
+        .schedule(
+            trigger_at,
+            &SimpleInput {
+                message: "via-convenience".to_string(),
+            },
+            Some(&hatchet_sdk::ScheduleOptions {
+                additional_metadata: Some(serde_json::json!({"source": "convenience"})),
+                priority: Some(2),
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert!(!scheduled.metadata_id.is_empty());
+    assert_eq!(scheduled.priority, Some(2));
+
+    let list = t.hatchet.schedules.list(Default::default()).await.unwrap();
+    assert!(
+        list.rows
+            .iter()
+            .any(|r| r.metadata_id == scheduled.metadata_id)
+    );
+
+    t.hatchet
+        .schedules
+        .delete(&scheduled.metadata_id)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_workflow_cron_convenience() {
+    let t = TestHarness::new("wf-cron-conv").await;
+
+    let task = t.simple_task("step");
+    let workflow = t
+        .hatchet
+        .workflow::<SimpleInput, SimpleOutput>(&t.prefixed("wf"))
+        .build()
+        .unwrap()
+        .add_task(&task);
+
+    let _worker = t.spawn_worker_for_workflow(&workflow).await;
+
+    let cron = workflow
+        .cron(
+            &t.prefixed("wf-cron"),
+            "0 * * * *",
+            &SimpleInput {
+                message: "workflow-cron".to_string(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let list = t.hatchet.crons.list(Default::default()).await.unwrap();
+    assert!(list.rows.iter().any(|r| r.metadata_id == cron.metadata_id));
+
+    t.hatchet.crons.delete(&cron.metadata_id).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_workflow_schedule_convenience() {
+    let t = TestHarness::new("wf-sched-conv").await;
+
+    let task = t.simple_task("step");
+    let workflow = t
+        .hatchet
+        .workflow::<SimpleInput, SimpleOutput>(&t.prefixed("wf"))
+        .build()
+        .unwrap()
+        .add_task(&task);
+
+    let _worker = t.spawn_worker_for_workflow(&workflow).await;
+
+    let trigger_at = hatchet_sdk::chrono::Utc::now() + hatchet_sdk::chrono::Duration::hours(3);
+    let scheduled = workflow
+        .schedule(
+            trigger_at,
+            &SimpleInput {
+                message: "workflow-schedule".to_string(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(!scheduled.metadata_id.is_empty());
+
+    let list = t.hatchet.schedules.list(Default::default()).await.unwrap();
+    assert!(
+        list.rows
+            .iter()
+            .any(|r| r.metadata_id == scheduled.metadata_id)
+    );
+
+    t.hatchet
+        .schedules
+        .delete(&scheduled.metadata_id)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
## Summary

Adds cron trigger and scheduled run management to the SDK, matching the official Go SDK's feature client pattern.

- `CronsClient` and `SchedulesClient` with full CRUD, exposed as `hatchet.crons` and `hatchet.schedules`
- `task.cron()` / `task.schedule()` / `workflow.cron()` / `workflow.schedule()` convenience methods
- Tenant ID extracted from JWT `sub` claim (optional, backward compatible)
- 5-field and 6-field cron expression validation via the `cron` crate
- `PaginationResponse` and `HatchetError::from_rest` shared across all feature clients
- 6 integration tests covering CRUD lifecycles and convenience methods

Depends on #42 for the test infrastructure.

## New dependencies

- `chrono` (DateTime for scheduled runs)
- `cron` (client-side expression validation)