### PR TITLE
feat: Add concurrency and rate limit controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Cargo.lock
 /target
 /.claude
 /.vscode
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,19 @@ path = "examples/input_json_schema.rs"
 [[example]]
 name = "streaming"
 path = "examples/streaming.rs"
+
+[[example]]
+name = "flow_control"
+path = "examples/flow_control.rs"
+
+[[example]]
+name = "rate_limits"
+path = "examples/rate_limits.rs"
+
+[[example]]
+name = "concurrency"
+path = "examples/concurrency.rs"
+
+[[example]]
+name = "workflow_concurrency"
+path = "examples/workflow_concurrency.rs"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,12 @@
 # Running code examples
 
-The example binaries define tasks showcasing different Hatchet functionality supported by the SDK. To run an exmaple, store your Hatchet API token in a `.env` file in the project root:
+The example binaries define tasks showcasing different Hatchet functionality supported by the SDK. To run an example, store your Hatchet API token in a `.env` file in the project root:
 
 ```
 HATCHET_CLIENT_TOKEN=xxx
 ```
+
+## General examples
 
 Tasks must be registered with Hatchet by a worker to be run successfully. Before running any of the task examples, start the worker binary:
 ```
@@ -19,3 +21,5 @@ Hatchet should assign your task to the worker you started. After completion, the
 ```
 Result: hello, world!
 ```
+
+Other examples runnable against the generic worker: `dag`, `error`, `dynamic_child_spawning`, `input_json_schema`, `streaming`, `concurrency`, `rate_limits`, `flow_control`, and `workflow_concurrency`.

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -1,0 +1,62 @@
+use hatchet_sdk::serde::{Deserialize, Serialize};
+use hatchet_sdk::{
+    ConcurrencyExpression, ConcurrencyLimitStrategy, Context, Hatchet, Runnable, tokio,
+};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(crate = "hatchet_sdk::serde")]
+pub struct TestInput {
+    pub provider_id: String,
+    pub index: i32,
+    pub delay_seconds: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(crate = "hatchet_sdk::serde")]
+pub struct TestOutput {
+    pub result: String,
+}
+
+pub async fn create_concurrency_task() -> hatchet_sdk::Task<TestInput, TestOutput> {
+    Hatchet::from_env().await.unwrap()
+        .task(
+            "concurrency_test",
+            async move |input: TestInput, ctx: Context| -> hatchet_sdk::anyhow::Result<TestOutput> {
+                ctx.log(&format!("Starting concurrency test {} for {}", input.index, input.provider_id)).await?;
+                tokio::time::sleep(Duration::from_secs(input.delay_seconds)).await;
+                Ok(TestOutput { result: "done".into() })
+            },
+        )
+        .concurrency(vec![ConcurrencyExpression {
+            expression: "input.provider_id".to_string(),
+            max_runs: 2,
+            limit_strategy: ConcurrencyLimitStrategy::GroupRoundRobin,
+        }])
+        .build()
+        .unwrap()
+}
+
+#[tokio::main]
+#[allow(dead_code)]
+async fn main() {
+    dotenvy::dotenv().ok();
+
+    let task = create_concurrency_task().await;
+
+    println!("Sending 20 events for concurrency test...");
+    for i in 0..20 {
+        let input = TestInput {
+            provider_id: "acme-corp".to_string(),
+            index: i,
+            delay_seconds: 15,
+        };
+
+        task.run_no_wait(&input, None).await.unwrap();
+    }
+
+    println!("\n========================================");
+    println!("          ALL TASKS QUEUED!             ");
+    println!("   Go observe them in the Hatchet UI!   ");
+    println!("========================================\n");
+}

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -19,13 +19,23 @@ pub struct TestOutput {
 }
 
 pub async fn create_concurrency_task() -> hatchet_sdk::Task<TestInput, TestOutput> {
-    Hatchet::from_env().await.unwrap()
+    Hatchet::from_env()
+        .await
+        .unwrap()
         .task(
             "concurrency_test",
-            async move |input: TestInput, ctx: Context| -> hatchet_sdk::anyhow::Result<TestOutput> {
-                ctx.log(&format!("Starting concurrency test {} for {}", input.index, input.provider_id)).await?;
+            async move |input: TestInput,
+                        ctx: Context|
+                        -> hatchet_sdk::anyhow::Result<TestOutput> {
+                ctx.log(&format!(
+                    "Starting concurrency test {} for {}",
+                    input.index, input.provider_id
+                ))
+                .await?;
                 tokio::time::sleep(Duration::from_secs(input.delay_seconds)).await;
-                Ok(TestOutput { result: "done".into() })
+                Ok(TestOutput {
+                    result: "done".into(),
+                })
             },
         )
         .concurrency(vec![ConcurrencyExpression {

--- a/examples/flow_control.rs
+++ b/examples/flow_control.rs
@@ -1,0 +1,71 @@
+use hatchet_sdk::serde::{Deserialize, Serialize};
+use hatchet_sdk::{
+    ConcurrencyExpression, ConcurrencyLimitStrategy, Context, Hatchet, RateLimit,
+    RateLimitDuration, Runnable, tokio,
+};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(crate = "hatchet_sdk::serde")]
+pub struct TestInput {
+    pub provider_id: String,
+    pub index: i32,
+    pub delay_seconds: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(crate = "hatchet_sdk::serde")]
+pub struct TestOutput {
+    pub result: String,
+}
+
+pub async fn create_flow_control_task() -> hatchet_sdk::Task<TestInput, TestOutput> {
+    Hatchet::from_env().await.unwrap()
+        .task(
+            "flow_control_test",
+            async move |input: TestInput, ctx: Context| -> hatchet_sdk::anyhow::Result<TestOutput> {
+                ctx.log(&format!("Starting flow control test {} for {}", input.index, input.provider_id)).await?;
+                tokio::time::sleep(Duration::from_secs(input.delay_seconds)).await;
+                Ok(TestOutput { result: "done".into() })
+            },
+        )
+        .concurrency(vec![ConcurrencyExpression {
+            expression: "input.provider_id".to_string(),
+            max_runs: 2,
+            limit_strategy: ConcurrencyLimitStrategy::GroupRoundRobin,
+        }])
+        .rate_limits(vec![RateLimit::Dynamic {
+            key: "provider-flow-rate-limit".to_string(),
+            key_expr: "input.provider_id".to_string(),
+            units: 1,
+            units_expr: None,
+            limit: 5,
+            duration: RateLimitDuration::Minute,
+        }])
+        .build()
+        .unwrap()
+}
+
+#[tokio::main]
+#[allow(dead_code)]
+async fn main() {
+    dotenvy::dotenv().ok();
+
+    let task = create_flow_control_task().await;
+
+    println!("Sending 20 events for flow control test...");
+    for i in 0..20 {
+        let input = TestInput {
+            provider_id: "acme-corp".to_string(),
+            index: i,
+            delay_seconds: 2,
+        };
+
+        task.run_no_wait(&input, None).await.unwrap();
+    }
+
+    println!("\n========================================");
+    println!("          ALL TASKS QUEUED!             ");
+    println!("   Go observe them in the Hatchet UI!   ");
+    println!("========================================\n");
+}

--- a/examples/flow_control.rs
+++ b/examples/flow_control.rs
@@ -20,13 +20,23 @@ pub struct TestOutput {
 }
 
 pub async fn create_flow_control_task() -> hatchet_sdk::Task<TestInput, TestOutput> {
-    Hatchet::from_env().await.unwrap()
+    Hatchet::from_env()
+        .await
+        .unwrap()
         .task(
             "flow_control_test",
-            async move |input: TestInput, ctx: Context| -> hatchet_sdk::anyhow::Result<TestOutput> {
-                ctx.log(&format!("Starting flow control test {} for {}", input.index, input.provider_id)).await?;
+            async move |input: TestInput,
+                        ctx: Context|
+                        -> hatchet_sdk::anyhow::Result<TestOutput> {
+                ctx.log(&format!(
+                    "Starting flow control test {} for {}",
+                    input.index, input.provider_id
+                ))
+                .await?;
                 tokio::time::sleep(Duration::from_secs(input.delay_seconds)).await;
-                Ok(TestOutput { result: "done".into() })
+                Ok(TestOutput {
+                    result: "done".into(),
+                })
             },
         )
         .concurrency(vec![ConcurrencyExpression {

--- a/examples/rate_limits.rs
+++ b/examples/rate_limits.rs
@@ -1,0 +1,66 @@
+use hatchet_sdk::serde::{Deserialize, Serialize};
+use hatchet_sdk::{
+    Context, Hatchet, RateLimit,
+    RateLimitDuration, Runnable, tokio,
+};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(crate = "hatchet_sdk::serde")]
+pub struct TestInput {
+    pub provider_id: String,
+    pub index: i32,
+    pub delay_seconds: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(crate = "hatchet_sdk::serde")]
+pub struct TestOutput {
+    pub result: String,
+}
+
+pub async fn create_rate_limit_task() -> hatchet_sdk::Task<TestInput, TestOutput> {
+    Hatchet::from_env().await.unwrap()
+        .task(
+            "rate_limit_test",
+            async move |input: TestInput, ctx: Context| -> hatchet_sdk::anyhow::Result<TestOutput> {
+                ctx.log(&format!("Starting rate limit test {} for {}", input.index, input.provider_id)).await?;
+                tokio::time::sleep(Duration::from_secs(input.delay_seconds)).await;
+                Ok(TestOutput { result: "done".into() })
+            },
+        )
+        .rate_limits(vec![RateLimit::Dynamic {
+            key: "provider-rate-limit".to_string(),
+            key_expr: "input.provider_id".to_string(),
+            units: 1,
+            units_expr: None,
+            limit: 5,
+            duration: RateLimitDuration::Minute,
+        }])
+        .build()
+        .unwrap()
+}
+
+#[tokio::main]
+#[allow(dead_code)]
+async fn main() {
+    dotenvy::dotenv().ok();
+
+    let task = create_rate_limit_task().await;
+
+    println!("Sending 20 events for rate limit test...");
+    for i in 0..20 {
+        let input = TestInput {
+            provider_id: "acme-corp".to_string(),
+            index: i,
+            delay_seconds: 15,
+        };
+
+        task.run_no_wait(&input, None).await.unwrap();
+    }
+
+    println!("\n========================================");
+    println!("          ALL TASKS QUEUED!             ");
+    println!("   Go observe them in the Hatchet UI!   ");
+    println!("========================================\n");
+}

--- a/examples/rate_limits.rs
+++ b/examples/rate_limits.rs
@@ -1,8 +1,5 @@
 use hatchet_sdk::serde::{Deserialize, Serialize};
-use hatchet_sdk::{
-    Context, Hatchet, RateLimit,
-    RateLimitDuration, Runnable, tokio,
-};
+use hatchet_sdk::{Context, Hatchet, RateLimit, RateLimitDuration, Runnable, tokio};
 use std::time::Duration;
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -20,13 +17,23 @@ pub struct TestOutput {
 }
 
 pub async fn create_rate_limit_task() -> hatchet_sdk::Task<TestInput, TestOutput> {
-    Hatchet::from_env().await.unwrap()
+    Hatchet::from_env()
+        .await
+        .unwrap()
         .task(
             "rate_limit_test",
-            async move |input: TestInput, ctx: Context| -> hatchet_sdk::anyhow::Result<TestOutput> {
-                ctx.log(&format!("Starting rate limit test {} for {}", input.index, input.provider_id)).await?;
+            async move |input: TestInput,
+                        ctx: Context|
+                        -> hatchet_sdk::anyhow::Result<TestOutput> {
+                ctx.log(&format!(
+                    "Starting rate limit test {} for {}",
+                    input.index, input.provider_id
+                ))
+                .await?;
                 tokio::time::sleep(Duration::from_secs(input.delay_seconds)).await;
-                Ok(TestOutput { result: "done".into() })
+                Ok(TestOutput {
+                    result: "done".into(),
+                })
             },
         )
         .rate_limits(vec![RateLimit::Dynamic {

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -24,6 +24,22 @@ use input_json_schema::create_schema_workflow;
 mod streaming;
 use streaming::create_streaming_task;
 
+#[path = "concurrency.rs"]
+mod concurrency;
+use concurrency::create_concurrency_task;
+
+#[path = "rate_limits.rs"]
+mod rate_limits;
+use rate_limits::create_rate_limit_task;
+
+#[path = "flow_control.rs"]
+mod flow_control;
+use flow_control::create_flow_control_task;
+
+#[path = "workflow_concurrency.rs"]
+mod workflow_concurrency;
+use workflow_concurrency::create_workflow_concurrency;
+
 #[tokio::main]
 #[allow(dead_code)]
 async fn main() {
@@ -40,6 +56,10 @@ async fn main() {
     let (parent_workflow, child_workflow) = create_child_spawning_workflow().await;
     let schema_workflow = create_schema_workflow().await;
     let streaming_task = create_streaming_task().await;
+    let concurrency_task = create_concurrency_task().await;
+    let rate_limit_task = create_rate_limit_task().await;
+    let flow_control_task = create_flow_control_task().await;
+    let workflow_concurrency = create_workflow_concurrency().await;
 
     hatchet
         .worker("example-worker")
@@ -52,6 +72,10 @@ async fn main() {
         .add_task_or_workflow(&child_workflow)
         .add_task_or_workflow(&schema_workflow)
         .add_task_or_workflow(&streaming_task)
+        .add_task_or_workflow(&concurrency_task)
+        .add_task_or_workflow(&rate_limit_task)
+        .add_task_or_workflow(&flow_control_task)
+        .add_task_or_workflow(&workflow_concurrency)
         .start()
         .await
         .unwrap();

--- a/examples/workflow_concurrency.rs
+++ b/examples/workflow_concurrency.rs
@@ -1,0 +1,84 @@
+use hatchet_sdk::serde::{Deserialize, Serialize};
+use hatchet_sdk::{
+    ConcurrencyExpression, ConcurrencyLimitStrategy, Context, Hatchet, Runnable, tokio,
+};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(crate = "hatchet_sdk::serde")]
+pub struct TestInput {
+    pub provider_id: String,
+    pub index: i32,
+    pub delay_seconds: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(crate = "hatchet_sdk::serde")]
+pub struct TestOutput {
+    pub result: String,
+}
+
+/// Returns a workflow that demonstrates concurrency defined on a **Task** being
+/// hoisted to the **Workflow** level when `Workflow::add_task()` is called.
+///
+/// Without the hoisting fix, these concurrency rules would be silently dropped
+/// and all 20 runs would execute without any concurrency limit.
+pub async fn create_workflow_concurrency() -> hatchet_sdk::Workflow<TestInput, serde_json::Value> {
+    let hatchet = Hatchet::from_env().await.unwrap();
+
+    // Define a task with concurrency — max 2 concurrent runs per provider_id.
+    let task = hatchet
+        .task(
+            "wf_conc_step",
+            async move |input: TestInput, ctx: Context| -> hatchet_sdk::anyhow::Result<TestOutput> {
+                ctx.log(&format!(
+                    "Starting workflow concurrency test {} for {}",
+                    input.index, input.provider_id
+                ))
+                .await?;
+                tokio::time::sleep(Duration::from_secs(input.delay_seconds)).await;
+                Ok(TestOutput {
+                    result: "done".into(),
+                })
+            },
+        )
+        .concurrency(vec![ConcurrencyExpression {
+            expression: "input.provider_id".to_string(),
+            max_runs: 2,
+            limit_strategy: ConcurrencyLimitStrategy::GroupRoundRobin,
+        }])
+        .build()
+        .unwrap();
+
+    // Wrap the task inside a Workflow. The task's concurrency expressions
+    // are hoisted to the workflow level automatically.
+    hatchet
+        .workflow::<TestInput, serde_json::Value>("workflow-concurrency-test")
+        .build()
+        .unwrap()
+        .add_task(&task)
+}
+
+#[tokio::main]
+#[allow(dead_code)]
+async fn main() {
+    dotenvy::dotenv().ok();
+
+    let workflow = create_workflow_concurrency().await;
+
+    println!("Sending 20 events for workflow concurrency test...");
+    for i in 0..20 {
+        let input = TestInput {
+            provider_id: "acme-corp".to_string(),
+            index: i,
+            delay_seconds: 15,
+        };
+
+        workflow.run_no_wait(&input, None).await.unwrap();
+    }
+
+    println!("\n========================================");
+    println!("       ALL WORKFLOW RUNS QUEUED!        ");
+    println!("   Go observe them in the Hatchet UI!   ");
+    println!("========================================\n");
+}

--- a/examples/workflow_concurrency.rs
+++ b/examples/workflow_concurrency.rs
@@ -30,7 +30,9 @@ pub async fn create_workflow_concurrency() -> hatchet_sdk::Workflow<TestInput, s
     let task = hatchet
         .task(
             "wf_conc_step",
-            async move |input: TestInput, ctx: Context| -> hatchet_sdk::anyhow::Result<TestOutput> {
+            async move |input: TestInput,
+                        ctx: Context|
+                        -> hatchet_sdk::anyhow::Result<TestOutput> {
                 ctx.log(&format!(
                     "Starting workflow concurrency test {} for {}",
                     input.index, input.provider_id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,16 @@ pub use clients::rest::features::pagination::PaginationResponse;
 pub use clients::rest::features::schedules::{
     CreateScheduleOpts, ListSchedulesOpts, ScheduleOptions, ScheduledRun, ScheduledRunList,
 };
-pub(crate) use clients::{Configuration, GetWorkflowRunResponse, WorkflowStatus};
+pub(crate) use clients::Configuration;
+pub use clients::{GetWorkflowRunResponse, WorkflowStatus};
 pub use clients::{CronsClient, RunsClient, SchedulesClient};
 pub(crate) use config::{HatchetConfig, TlsStrategy};
 pub use context::Context;
 pub use error::HatchetError;
-pub use runnables::{Runnable, Task, TriggerWorkflowOptionsBuilder, Workflow};
+pub use runnables::{
+    ConcurrencyExpression, ConcurrencyLimitStrategy, RateLimit, RateLimitDuration, Runnable, Task,
+    TriggerWorkflowOptionsBuilder, Workflow,
+};
 pub use utils::EmptyModel;
 pub(crate) use utils::{EXECUTION_CONTEXT, ExecutionContext, proto_timestamp_now};
 pub use worker::{Register, Worker};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod runnables;
 pub mod utils;
 pub mod worker;
 
+pub(crate) use clients::Configuration;
 pub use clients::hatchet::Hatchet;
 pub use clients::rest::features::crons::{
     CreateCronOpts, CronOptions, CronTrigger, CronTriggerList, ListCronsOpts,
@@ -15,9 +16,8 @@ pub use clients::rest::features::pagination::PaginationResponse;
 pub use clients::rest::features::schedules::{
     CreateScheduleOpts, ListSchedulesOpts, ScheduleOptions, ScheduledRun, ScheduledRunList,
 };
-pub(crate) use clients::Configuration;
-pub use clients::{GetWorkflowRunResponse, WorkflowStatus};
 pub use clients::{CronsClient, RunsClient, SchedulesClient};
+pub use clients::{GetWorkflowRunResponse, WorkflowStatus};
 pub(crate) use config::{HatchetConfig, TlsStrategy};
 pub use context::Context;
 pub use error::HatchetError;

--- a/src/runnables/flow_control.rs
+++ b/src/runnables/flow_control.rs
@@ -1,0 +1,142 @@
+use serde::{Deserialize, Serialize};
+
+use crate::clients::grpc::v1::workflows::{
+    ConcurrencyLimitStrategy as ProtoConcurrencyLimitStrategy, Concurrency as ProtoConcurrency,
+    CreateTaskRateLimit, RateLimitDuration as ProtoRateLimitDuration,
+};
+
+/// Strategy to apply when the concurrency limit is reached.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ConcurrencyLimitStrategy {
+    /// Cancel the currently in-progress run when a new one arrives.
+    CancelInProgress,
+    /// Distribute runs across concurrency keys in a round-robin fashion.
+    GroupRoundRobin,
+    /// Cancel the newest run when the limit is reached.
+    CancelNewest,
+}
+
+impl ConcurrencyLimitStrategy {
+    pub(crate) fn to_proto(&self) -> i32 {
+        match self {
+            ConcurrencyLimitStrategy::CancelInProgress => {
+                ProtoConcurrencyLimitStrategy::CancelInProgress as i32
+            }
+            ConcurrencyLimitStrategy::GroupRoundRobin => {
+                ProtoConcurrencyLimitStrategy::GroupRoundRobin as i32
+            }
+            ConcurrencyLimitStrategy::CancelNewest => {
+                ProtoConcurrencyLimitStrategy::CancelNewest as i32
+            }
+        }
+    }
+}
+
+/// A concurrency expression controlling how many workflow runs can execute
+/// concurrently for a given dynamic key.
+///
+/// Concurrency is set at the **workflow level**.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConcurrencyExpression {
+    /// A CEL expression evaluated against task input to derive the concurrency key
+    /// (e.g. `"input.provider_id"`).
+    pub expression: String,
+    /// Maximum number of concurrent runs sharing the same key.
+    pub max_runs: i32,
+    /// Strategy to apply when the limit is reached.
+    pub limit_strategy: ConcurrencyLimitStrategy,
+}
+
+impl ConcurrencyExpression {
+    pub(crate) fn to_proto(&self) -> ProtoConcurrency {
+        ProtoConcurrency {
+            expression: self.expression.clone(),
+            max_runs: Some(self.max_runs),
+            limit_strategy: Some(self.limit_strategy.to_proto()),
+        }
+    }
+}
+
+/// Duration window for dynamic rate limits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RateLimitDuration {
+    Second,
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+impl RateLimitDuration {
+    pub(crate) fn to_proto(&self) -> i32 {
+        match self {
+            RateLimitDuration::Second => ProtoRateLimitDuration::Second as i32,
+            RateLimitDuration::Minute => ProtoRateLimitDuration::Minute as i32,
+            RateLimitDuration::Hour => ProtoRateLimitDuration::Hour as i32,
+            RateLimitDuration::Day => ProtoRateLimitDuration::Day as i32,
+            RateLimitDuration::Week => ProtoRateLimitDuration::Week as i32,
+            RateLimitDuration::Month => ProtoRateLimitDuration::Month as i32,
+            RateLimitDuration::Year => ProtoRateLimitDuration::Year as i32,
+        }
+    }
+}
+
+/// A rate limit applied at the **task/step level**.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RateLimit {
+    /// A static rate limit with a fixed key known at registration time.
+    Static {
+        /// The rate limit key (must already be configured on the Hatchet server).
+        key: String,
+        /// Number of rate limit units this task consumes per execution.
+        units: i32,
+    },
+    /// A dynamic rate limit whose key is derived at runtime via a CEL expression.
+    Dynamic {
+        /// The base rate limit key string.
+        key: String,
+        /// A CEL expression evaluated against task input to determine the rate limit key.
+        key_expr: String,
+        /// Number of rate limit units this task consumes per execution.
+        units: i32,
+        /// Optional CEL expression evaluated against task input to determine the number of units
+        /// consumed per execution (e.g. `"input.weight"`). When `None`, `units` is used instead.
+        units_expr: Option<String>,
+        /// Total number of rate limit units available in the window.
+        limit: i32,
+        /// The duration window for the rate limit.
+        duration: RateLimitDuration,
+    },
+}
+
+impl RateLimit {
+    pub(crate) fn to_proto(&self) -> CreateTaskRateLimit {
+        match self {
+            RateLimit::Static { key, units } => CreateTaskRateLimit {
+                key: key.clone(),
+                units: Some(*units),
+                key_expr: None,
+                units_expr: None,
+                limit_values_expr: None,
+                duration: None,
+            },
+            RateLimit::Dynamic {
+                key,
+                key_expr,
+                units,
+                units_expr,
+                limit,
+                duration,
+            } => CreateTaskRateLimit {
+                key: key.clone(),
+                units: Some(*units),
+                key_expr: Some(key_expr.clone()),
+                units_expr: units_expr.clone(),
+                limit_values_expr: Some(limit.to_string()),
+                duration: Some(duration.to_proto()),
+            },
+        }
+    }
+}

--- a/src/runnables/flow_control.rs
+++ b/src/runnables/flow_control.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::clients::grpc::v1::workflows::{
-    ConcurrencyLimitStrategy as ProtoConcurrencyLimitStrategy, Concurrency as ProtoConcurrency,
+    Concurrency as ProtoConcurrency, ConcurrencyLimitStrategy as ProtoConcurrencyLimitStrategy,
     CreateTaskRateLimit, RateLimitDuration as ProtoRateLimitDuration,
 };
 

--- a/src/runnables/mod.rs
+++ b/src/runnables/mod.rs
@@ -1,8 +1,10 @@
+mod flow_control;
 mod options;
 mod runnable;
 mod task;
 mod workflow;
 
+pub use flow_control::{ConcurrencyExpression, ConcurrencyLimitStrategy, RateLimit, RateLimitDuration};
 pub use options::{TriggerWorkflowOptions, TriggerWorkflowOptionsBuilder};
 pub(crate) use runnable::ExtractRunnableOutput;
 pub use runnable::Runnable;

--- a/src/runnables/mod.rs
+++ b/src/runnables/mod.rs
@@ -4,7 +4,9 @@ mod runnable;
 mod task;
 mod workflow;
 
-pub use flow_control::{ConcurrencyExpression, ConcurrencyLimitStrategy, RateLimit, RateLimitDuration};
+pub use flow_control::{
+    ConcurrencyExpression, ConcurrencyLimitStrategy, RateLimit, RateLimitDuration,
+};
 pub use options::{TriggerWorkflowOptions, TriggerWorkflowOptionsBuilder};
 pub(crate) use runnable::ExtractRunnableOutput;
 pub use runnable::Runnable;

--- a/src/runnables/task.rs
+++ b/src/runnables/task.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+use super::flow_control::{ConcurrencyExpression, RateLimit};
 use super::workflow::DefaultFilter;
 use super::{ExtractRunnableOutput, TriggerWorkflowOptions};
 use crate::clients::grpc::v1::workflows::{CreateTaskOpts, CreateWorkflowVersionRequest};
@@ -90,6 +91,10 @@ pub struct Task<I, O> {
     execution_timeout: std::time::Duration,
     #[builder(default)]
     input_json_schema: Option<serde_json::Value>,
+    #[builder(default = vec![])]
+    rate_limits: Vec<RateLimit>,
+    #[builder(default = vec![])]
+    pub(crate) concurrency: Vec<ConcurrencyExpression>,
 }
 
 impl<I, O> Task<I, O>
@@ -134,7 +139,7 @@ where
             inputs: String::from("{{}}"),
             parents: self.parents.clone(),
             retries: self.retries,
-            rate_limits: vec![],
+            rate_limits: self.rate_limits.iter().map(|rl| rl.to_proto()).collect(),
             worker_labels: std::collections::HashMap::new(),
             backoff_factor: None,
             backoff_max_seconds: None,
@@ -158,7 +163,7 @@ where
             on_failure_task: None,
             sticky: None,
             default_priority: Some(self.default_priority),
-            concurrency_arr: vec![],
+            concurrency_arr: self.concurrency.iter().map(|c| c.to_proto()).collect(),
             default_filters: self
                 .default_filters
                 .clone()

--- a/src/runnables/workflow.rs
+++ b/src/runnables/workflow.rs
@@ -2,6 +2,8 @@ use derive_builder::Builder;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+use super::flow_control::ConcurrencyExpression;
+
 use super::{ExecutableTask, ExtractRunnableOutput, Task, TriggerWorkflowOptions};
 use crate::clients::grpc::v1::workflows::{
     CreateTaskOpts, CreateWorkflowVersionRequest, DefaultFilter as DefaultFilterProto,
@@ -37,6 +39,8 @@ pub struct Workflow<I, O> {
     default_filters: Vec<DefaultFilter>,
     #[builder(default)]
     input_json_schema: Option<serde_json::Value>,
+    #[builder(default = vec![])]
+    concurrency: Vec<ConcurrencyExpression>,
     #[builder(default = std::marker::PhantomData)]
     _phantom: std::marker::PhantomData<(I, O)>,
 }
@@ -61,6 +65,7 @@ where
 
         self.tasks.push(task.to_task_proto(&self.name));
         self.executable_tasks.push(task.into_executable());
+        self.concurrency.extend(task.concurrency.clone());
         self
     }
 
@@ -77,7 +82,7 @@ where
             on_failure_task: None,
             sticky: None,
             default_priority: Some(self.default_priority),
-            concurrency_arr: vec![],
+            concurrency_arr: self.concurrency.iter().map(|c| c.to_proto()).collect(),
             default_filters: self
                 .default_filters
                 .clone()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -259,6 +259,19 @@ struct AddOutput {
     value: i64,
 }
 
+/// Input used by `test_rate_limit_units_expr`.
+/// The `cost` field is referenced in the `units_expr` CEL expression so
+/// the server can compute how many rate-limit units each run consumes.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct CostInput {
+    cost: i32,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct CostOutput {
+    done: bool,
+}
+
 #[tokio::test]
 async fn test_workflow_with_input_json_schema() {
     let t = TestHarness::new("json-schema").await;
@@ -547,4 +560,310 @@ async fn test_workflow_schedule_convenience() {
         .delete(&scheduled.metadata_id)
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn test_task_with_flow_control() {
+    let t = TestHarness::new("flow-control").await;
+
+    let task = t
+        .hatchet
+        .task(
+            &t.prefixed("step"),
+            async move |input: SimpleInput,
+                        _ctx: hatchet_sdk::Context|
+                        -> anyhow::Result<SimpleOutput> {
+                Ok(SimpleOutput {
+                    transformed_message: format!("synced:{}", input.message),
+                })
+            },
+        )
+        .concurrency(vec![hatchet_sdk::ConcurrencyExpression {
+            expression: "\"test\"".to_string(),
+            max_runs: 2,
+            limit_strategy: hatchet_sdk::ConcurrencyLimitStrategy::GroupRoundRobin,
+        }])
+        .rate_limits(vec![hatchet_sdk::RateLimit::Dynamic {
+            key: "test-limit".to_string(),
+            key_expr: "\"test\"".to_string(),
+            units: 1,
+            units_expr: None,
+            limit: 10,
+            duration: hatchet_sdk::RateLimitDuration::Minute,
+        }])
+        .build()
+        .unwrap();
+
+    let _worker = t.spawn_worker_for_task(&task).await;
+
+    let output = task
+        .run(
+            &SimpleInput {
+                message: "payload".to_string(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!("synced:payload", output.transformed_message);
+}
+
+#[tokio::test]
+async fn test_concurrency_cancel_newest() {
+    let t = TestHarness::new("conc-cancel").await;
+
+    // Sleep for 10s so run1 is definitively still in-flight when run2 is submitted.
+    let task = t
+        .hatchet
+        .task(
+            &t.prefixed("step"),
+            async move |_input: SimpleInput,
+                        _ctx: hatchet_sdk::Context|
+                        -> anyhow::Result<SimpleOutput> {
+                tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                Ok(SimpleOutput {
+                    transformed_message: "done".to_string(),
+                })
+            },
+        )
+        .concurrency(vec![hatchet_sdk::ConcurrencyExpression {
+            expression: "\"test\"".to_string(),
+            max_runs: 1,
+            limit_strategy: hatchet_sdk::ConcurrencyLimitStrategy::CancelNewest,
+        }])
+        .build()
+        .unwrap();
+
+    let _worker = t.spawn_worker_for_task(&task).await;
+
+    // Run first task
+    let _run1 = task
+        .run_no_wait(
+            &SimpleInput {
+                message: "payload".to_string(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Wait for run1 to transition to Running (2s is plenty; task runs for 10s)
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Run second task, which should exceed max_runs and be cancelled
+    let run2 = task
+        .run_no_wait(
+            &SimpleInput {
+                message: "payload".to_string(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Poll until run2 reaches a terminal state (Cancelled or Failed).
+    // The concurrency engine processes cancellations asynchronously.
+    use hatchet_sdk::WorkflowStatus;
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
+    let mut final_status: Option<WorkflowStatus> = None;
+    while tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        let res2 = t
+            .hatchet
+            .workflow_rest_client
+            .get(&run2)
+            .await
+            .unwrap();
+        println!("RUN2 RESULT: {:?}", res2);
+        if matches!(res2.run.status, WorkflowStatus::Cancelled | WorkflowStatus::Failed) {
+            final_status = Some(res2.run.status);
+            break;
+        }
+    }
+    assert!(
+        matches!(final_status, Some(WorkflowStatus::Cancelled) | Some(WorkflowStatus::Failed)),
+        "Expected Cancelled or Failed, got: {:?}",
+        final_status
+    );
+}
+
+/// Verifies that `units_expr` on `RateLimit::Dynamic` is correctly wired to
+/// the Hatchet engine and affects the number of rate-limit units consumed per run.
+///
+/// **Regression oracle:** if `units_expr` were broken (silently `None`) the
+/// server would fall back to the static `units = 1` field.  With a `limit` of
+/// 2 and `units = 1`, two runs could proceed before the bucket empties.
+/// With `units_expr = "input.cost"` and `cost = 2`, a single run exhausts the
+/// entire bucket — so the second run must be `Queued` (rate-limited).  If it
+/// completes, `units_expr` is not being forwarded.
+#[tokio::test]
+async fn test_rate_limit_units_expr() {
+    let t = TestHarness::new("rl-units-expr").await;
+
+    // Use a test-scoped bucket key so this test doesn't share quota with others.
+    let bucket_key = t.prefixed("bucket");
+    // CEL string literal: all runs share the same named bucket.
+    let bucket_key_expr = format!("\"{}\"", bucket_key);
+
+    let task = t
+        .hatchet
+        .task(
+            &t.prefixed("step"),
+            async move |_input: CostInput,
+                        _ctx: hatchet_sdk::Context|
+                        -> anyhow::Result<CostOutput> {
+                // Intentionally slow so run1 is still registered in the rate-limit
+                // window when run2 is submitted.
+                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                Ok(CostOutput { done: true })
+            },
+        )
+        .rate_limits(vec![hatchet_sdk::RateLimit::Dynamic {
+            key: bucket_key,
+            key_expr: bucket_key_expr,
+            // Static fallback — if units_expr is broken, each run costs 1 unit
+            // and run2 would still fit inside the limit-2 bucket.
+            units: 1,
+            // Dynamic cost via CEL: each run costs `input.cost` units.
+            // run1 sends cost=2, which exhausts the entire limit-2 bucket.
+            units_expr: Some("input.cost".to_string()),
+            limit: 2,
+            duration: hatchet_sdk::RateLimitDuration::Minute,
+        }])
+        .build()
+        .unwrap();
+
+    let _worker = t.spawn_worker_for_task(&task).await;
+
+    // Run 1: cost=2 → consumes all 2 units from the bucket.
+    let _run1 = task
+        .run_no_wait(&CostInput { cost: 2 }, None)
+        .await
+        .unwrap();
+
+    // Brief pause to let the server process run1's rate-limit deduction
+    // before run2 is submitted.
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    // Run 2: cost=1, but 0 units remain — should be rate-limited (Queued).
+    let run2 = task
+        .run_no_wait(&CostInput { cost: 1 }, None)
+        .await
+        .unwrap();
+
+    // Give the concurrency engine time to make a scheduling decision.
+    // We do NOT wait long enough for the rate-limit window to reset (1 min).
+    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+    use hatchet_sdk::WorkflowStatus;
+    let res2 = t
+        .hatchet
+        .workflow_rest_client
+        .get(&run2)
+        .await
+        .unwrap();
+
+    println!("RUN2 STATUS: {:?}", res2.run.status);
+
+    assert!(
+        matches!(res2.run.status, WorkflowStatus::Queued),
+        "Expected run2 to be rate-limited (Queued) because units_expr should have \
+         exhausted the bucket with run1. If this fails, units_expr may not be \
+         forwarded to the server. Got: {:?}",
+        res2.run.status
+    );
+}
+/// Verifies that concurrency expressions defined on a Task are correctly
+/// hoisted to the Workflow when the task is added via `Workflow::add_task()`.
+///
+/// This mirrors `test_concurrency_cancel_newest` but wraps the task in a
+/// Workflow. Before the hoisting fix, concurrency would have been silently
+/// dropped and the second run would NOT be cancelled.
+#[tokio::test]
+async fn test_workflow_hoists_task_concurrency() {
+    let t = TestHarness::new("wf-conc").await;
+
+    // Define a task with CancelNewest concurrency (max_runs: 1).
+    // Sleep for 10s so run1 is definitively still in-flight when run2 is submitted.
+    let task = t
+        .hatchet
+        .task(
+            &t.prefixed("step"),
+            async move |_input: SimpleInput,
+                        _ctx: hatchet_sdk::Context|
+                        -> anyhow::Result<SimpleOutput> {
+                tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                Ok(SimpleOutput {
+                    transformed_message: "done".to_string(),
+                })
+            },
+        )
+        .concurrency(vec![hatchet_sdk::ConcurrencyExpression {
+            expression: "\"test\"".to_string(),
+            max_runs: 1,
+            limit_strategy: hatchet_sdk::ConcurrencyLimitStrategy::CancelNewest,
+        }])
+        .build()
+        .unwrap();
+
+    // Wrap the task in a Workflow. The concurrency should be hoisted.
+    let workflow = t
+        .hatchet
+        .workflow::<SimpleInput, serde_json::Value>(&t.prefixed("workflow"))
+        .build()
+        .unwrap()
+        .add_task(&task);
+
+    let _worker = t.spawn_worker_for_workflow(&workflow).await;
+
+    // Run first workflow — should start executing
+    let _run1 = workflow
+        .run_no_wait(
+            &SimpleInput {
+                message: "payload".to_string(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Wait for run1 to transition to Running (2s is plenty; task runs for 10s)
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Run second workflow — should exceed max_runs and be cancelled
+    let run2 = workflow
+        .run_no_wait(
+            &SimpleInput {
+                message: "payload".to_string(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Poll until run2 reaches a terminal state (Cancelled or Failed).
+    // The concurrency engine processes cancellations asynchronously.
+    use hatchet_sdk::WorkflowStatus;
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
+    let mut final_status: Option<WorkflowStatus> = None;
+    while tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        let res2 = t
+            .hatchet
+            .workflow_rest_client
+            .get(&run2)
+            .await
+            .unwrap();
+        println!("RUN2 RESULT: {:?}", res2);
+        if matches!(res2.run.status, WorkflowStatus::Cancelled | WorkflowStatus::Failed) {
+            final_status = Some(res2.run.status);
+            break;
+        }
+    }
+    assert!(
+        matches!(final_status, Some(WorkflowStatus::Cancelled) | Some(WorkflowStatus::Failed)),
+        "Expected Cancelled or Failed, got: {:?}",
+        final_status
+    );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -669,20 +669,21 @@ async fn test_concurrency_cancel_newest() {
     let mut final_status: Option<WorkflowStatus> = None;
     while tokio::time::Instant::now() < deadline {
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-        let res2 = t
-            .hatchet
-            .workflow_rest_client
-            .get(&run2)
-            .await
-            .unwrap();
+        let res2 = t.hatchet.workflow_rest_client.get(&run2).await.unwrap();
         println!("RUN2 RESULT: {:?}", res2);
-        if matches!(res2.run.status, WorkflowStatus::Cancelled | WorkflowStatus::Failed) {
+        if matches!(
+            res2.run.status,
+            WorkflowStatus::Cancelled | WorkflowStatus::Failed
+        ) {
             final_status = Some(res2.run.status);
             break;
         }
     }
     assert!(
-        matches!(final_status, Some(WorkflowStatus::Cancelled) | Some(WorkflowStatus::Failed)),
+        matches!(
+            final_status,
+            Some(WorkflowStatus::Cancelled) | Some(WorkflowStatus::Failed)
+        ),
         "Expected Cancelled or Failed, got: {:?}",
         final_status
     );
@@ -757,12 +758,7 @@ async fn test_rate_limit_units_expr() {
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
     use hatchet_sdk::WorkflowStatus;
-    let res2 = t
-        .hatchet
-        .workflow_rest_client
-        .get(&run2)
-        .await
-        .unwrap();
+    let res2 = t.hatchet.workflow_rest_client.get(&run2).await.unwrap();
 
     println!("RUN2 STATUS: {:?}", res2.run.status);
 
@@ -849,20 +845,21 @@ async fn test_workflow_hoists_task_concurrency() {
     let mut final_status: Option<WorkflowStatus> = None;
     while tokio::time::Instant::now() < deadline {
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-        let res2 = t
-            .hatchet
-            .workflow_rest_client
-            .get(&run2)
-            .await
-            .unwrap();
+        let res2 = t.hatchet.workflow_rest_client.get(&run2).await.unwrap();
         println!("RUN2 RESULT: {:?}", res2);
-        if matches!(res2.run.status, WorkflowStatus::Cancelled | WorkflowStatus::Failed) {
+        if matches!(
+            res2.run.status,
+            WorkflowStatus::Cancelled | WorkflowStatus::Failed
+        ) {
             final_status = Some(res2.run.status);
             break;
         }
     }
     assert!(
-        matches!(final_status, Some(WorkflowStatus::Cancelled) | Some(WorkflowStatus::Failed)),
+        matches!(
+            final_status,
+            Some(WorkflowStatus::Cancelled) | Some(WorkflowStatus::Failed)
+        ),
         "Expected Cancelled or Failed, got: {:?}",
         final_status
     );


### PR DESCRIPTION
Adding concurrency and rate limiting. Not much done in the way of logic, the main things here are to ensure the API on the usage side is ergonomic, and the values are properly sent to the Hatchet engine. 

## Confirmations
- [x] Tests added around "flow control"
- [x] Those tests pass
- [x] Examples created for the new API
- [x] All examples ran and observed correct behavior

## Concurrency

The API tries to stay consistent with the rest of the SDK, as well as the existing implementations from TS, etc


```rs
// Source
pub enum ConcurrencyLimitStrategy {
    /// Cancel the currently in-progress run when a new one arrives.
    CancelInProgress,
    /// Distribute runs across concurrency keys in a round-robin fashion.
    GroupRoundRobin,
    /// Cancel the newest run when the limit is reached.
    CancelNewest,
}

// usage
.concurrency(vec![ConcurrencyExpression {
  expression: "input.provider_id".to_string(),
   max_runs: 2,
   limit_strategy: ConcurrencyLimitStrategy::GroupRoundRobin,
}])
```

## Rate Limits

```rs
.rate_limits(vec![RateLimit::Dynamic {
  key: "provider-rate-limit".to_string(),
  key_expr: "input.provider_id".to_string(),
  units: 1,
  units_expr: None,
  limit: 5,
  duration: RateLimitDuration::Minute,
}])
```

